### PR TITLE
refactor: multiple improvements & bug fixes

### DIFF
--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -7,9 +7,15 @@
 1. `npm i`
 
 2. To inscribe:
-    - Open `inscribe.js` and edit accordingly.
-    - Run with `npm run inscribe`.
+
+   - Open `inscribe.js` and edit accordingly.
+   - Run with `npm run inscribe`.
 
 3. To query a specific inscription for metadata:
-    - Open `read.js` and edit accordingly.
-    - Run with `npm run read`.    
+
+   - Open `read.js` and edit accordingly.
+   - Run with `npm run read`.
+
+4. To send cardinals (safe spendables, e.g. satas that do not have inscriptions and are not rare ordinals):
+   - Open `send.js` and edit accordingly.
+   - Run with `npm run send`.

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "inscribe": "node inscribe",
-    "read": "node read"
+    "read": "node read",
+    "send": "node send"
   },
   "author": "",
   "license": "ISC",

--- a/examples/node/send.js
+++ b/examples/node/send.js
@@ -1,0 +1,31 @@
+import { ordit } from "@sadoprotocol/ordit-sdk"; //import Ordit
+
+async function main() {
+  // Replace accordingly
+  const psbtTemplate = {
+    format: "p2wpkh",
+    network: "testnet",
+    pubKey: "02950611fedb407d34cc845101f2bdfb2e7e3ec075e1424015bbf2db75c8ebe696",
+    ins: [
+      {
+        address: "tb1qzxtxwhsqkh0yp6ne0mpefu99gn49a945m9hc28"
+      }
+    ],
+    outs: [
+      {
+        address: "tb1qzxtxwhsqkh0yp6ne0mpefu99gn49a945m9hc28",
+        cardinals: 1337
+      }
+    ]
+  };
+
+  // You need to sign this externally (tip: try window.unisat.signPsbt)
+  const psbt = await ordit.transactions.createPsbt(psbtTemplate);
+  console.log(psbt);
+
+  const hex = "your signed PSBT hex here";
+  const txId = await ordit.transactions.relayTransaction(hex, "testnet");
+  console.log(txId);
+}
+
+main();

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -31,6 +31,11 @@ export function getAddressFormat(address: string, network: Network) {
   return format;
 }
 
+export function getAddressType(address: string, network: Network): string | null {
+  const addressFormat = getAddressFormat(address, network).format;
+  return addressNameToType[addressFormat as AddressFormats];
+}
+
 export function getAddressesFromPublicKey(
   pubKey: string | Buffer,
   network: Network = "testnet",

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -31,7 +31,7 @@ export function getAddressFormat(address: string, network: Network) {
   return format;
 }
 
-export function getAddressType(address: string, network: Network): string | null {
+export function getAddressType(address: string, network: Network): AddressTypes {
   const addressFormat = getAddressFormat(address, network).format;
   return addressNameToType[addressFormat as AddressFormats];
 }

--- a/packages/sdk/src/transactions/relay.ts
+++ b/packages/sdk/src/transactions/relay.ts
@@ -2,15 +2,13 @@ import { OrditApi } from "../api";
 import { Network } from "../config/types";
 
 export async function relayTransaction(hex: string, network: Network) {
-  const txResponse = await OrditApi.fetch<{ success: boolean; rdata: Array<any> }>("utxo/relay", {
+  const txResponse = await OrditApi.fetch<{ success: boolean; rdata: string }>("utxo/relay", {
     data: { hex },
     network: network
   });
 
   if (txResponse.success && txResponse.rdata) {
-    return {
-      txid: txResponse.rdata
-    };
+    return txResponse.rdata;
   }
 
   throw new Error("Failed to relay transaction.");

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -227,7 +227,7 @@ export class Ordit {
       throw new Error("Invalid options provided.");
     }
 
-    const txResponse = await OrditApi.fetch<{ success: boolean; rdata: Array<any> }>("utxo/relay", {
+    const txResponse = await OrditApi.fetch<{ success: boolean; rdata: string }>("utxo/relay", {
       data: { hex },
       network: network ?? this.#network
     });
@@ -236,9 +236,7 @@ export class Ordit {
       throw new Error("Failed to relay transaction.");
     }
 
-    return {
-      txid: txResponse.rdata
-    };
+    return txResponse.rdata;
   }
 
   async getInscriptions() {

--- a/packages/sdk/src/wallet/index.ts
+++ b/packages/sdk/src/wallet/index.ts
@@ -71,7 +71,7 @@ export async function getWalletWithBalances(options: GetWalletOptions) {
     const unspent = await OrditApi.fetch<{ success: boolean; rdata: Array<any> }>("utxo/unspents", {
       network: options.network,
       data: {
-        address,
+        address: address.address,
         options: {
           txhex: true,
           notsafetospend: false,

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "sourceMap": true,
   },
   "exclude": ["./tests"]
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "./",
     "outDir": "./dist",
+    "sourceMap": true,
   },
   "include": ["./src", "./tests", "./src/types"]
 }


### PR DESCRIPTION
1. Fix `utxo/unspents` API call bug where the address is incorrectly passed into the payload
2. Enable source map for ease of debugging by developers
3. Directy return `txId` for the `utxo/relay` endpoint
4. Introduce `getAddressType` for the inverse derivation of an address format type
5. Add `send` example (send safe to spend sats, i.e. cardinals)