### PR TITLE
refactor!: update getAddress to generate new address based on provided path levels

### DIFF
--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -120,8 +120,8 @@ export function getAccountDataFromHdNode({
   hdNode,
   format = "legacy",
   network = "testnet",
-  accountIndex = 0,
-  index = 0
+  account = 0,
+  addressIndex = 0
 }: GetAccountDataFromHdNodeOptions) {
   if (!hdNode) {
     throw new Error("Invalid options provided.");
@@ -129,7 +129,7 @@ export function getAccountDataFromHdNode({
 
   const addressType = addressNameToType[format];
 
-  const fullDerivationPath = getDerivationPath(format, accountIndex, index);
+  const fullDerivationPath = getDerivationPath(format, account, addressIndex);
   const child = hdNode.derivePath(fullDerivationPath);
 
   const pubKey = format === "taproot" ? toXOnly(child.publicKey) : child.publicKey;
@@ -137,20 +137,24 @@ export function getAccountDataFromHdNode({
 
   const address = paymentObj.address!;
 
-  const account: Account = {
+  const accountData: Account = {
     address,
     pub: child.publicKey.toString("hex"),
     priv: child.privateKey!.toString("hex"),
     format,
     type: addressType,
-    derivationPath: fullDerivationPath
+    derivationPath: {
+      account,
+      addressIndex,
+      path: fullDerivationPath
+    }
   };
 
   if (format === "taproot") {
-    account.xkey = toXOnly(child.publicKey).toString("hex");
+    accountData.xkey = toXOnly(child.publicKey).toString("hex");
   }
 
-  return account;
+  return accountData;
 }
 
 export function getAllAccountsFromHdNode({ hdNode, network = "testnet" }: GetAllAccountsFromHDNodeOptions) {
@@ -177,10 +181,16 @@ export type Address = {
   pub: string;
 };
 
+export type Derivation = {
+  account: number;
+  addressIndex: number;
+  path: string
+}
+
 export type Account = Address & {
   priv: string;
   type: AddressTypes;
-  derivationPath: string;
+  derivationPath: Derivation;
 };
 
 type GetAddressesOptions = {
@@ -196,8 +206,8 @@ type GetAccountDataFromHdNodeOptions = {
   hdNode: BIP32Interface;
   format?: AddressFormats;
   network?: Network;
-  accountIndex?: number;
-  index?: number;
+  account?: number;
+  addressIndex?: number;
 };
 
 type GetAllAccountsFromHDNodeOptions = Omit<GetAccountDataFromHdNodeOptions, "format">;

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -132,8 +132,6 @@ export function getAccountDataFromHdNode({
   const fullDerivationPath = getDerivationPath(format, accountIndex, index)
   const child = hdNode.derivePath(fullDerivationPath)
 
-  console.log({fullDerivationPath ,pathLevles: getPathLevels(fullDerivationPath)})
-
   const pubKey = format === "taproot" ? toXOnly(child.publicKey) : child.publicKey;
   const paymentObj = createTransaction(pubKey, addressType, network);
 

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -3,7 +3,7 @@ import BIP32Factory, { BIP32Interface } from "bip32";
 
 import { Network } from "../config/types";
 import { getWalletKeys } from "../keys";
-import {createTransaction, getDerivationPath, getNetwork, getPathLevels, toXOnly} from "../utils";
+import { createTransaction, getDerivationPath, getNetwork, toXOnly } from "../utils";
 import { AddressFormats, addressFormats, addressNameToType, AddressTypes, addressTypeToName } from "./formats";
 
 export function getAddressFormat(address: string, network: Network) {
@@ -129,8 +129,8 @@ export function getAccountDataFromHdNode({
 
   const addressType = addressNameToType[format];
 
-  const fullDerivationPath = getDerivationPath(format, accountIndex, index)
-  const child = hdNode.derivePath(fullDerivationPath)
+  const fullDerivationPath = getDerivationPath(format, accountIndex, index);
+  const child = hdNode.derivePath(fullDerivationPath);
 
   const pubKey = format === "taproot" ? toXOnly(child.publicKey) : child.publicKey;
   const paymentObj = createTransaction(pubKey, addressType, network);
@@ -180,7 +180,7 @@ export type Address = {
 export type Account = Address & {
   priv: string;
   type: AddressTypes;
-  derivationPath: string
+  derivationPath: string;
 };
 
 type GetAddressesOptions = {

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -38,30 +38,34 @@ export function createTransaction(
   return bitcoin.payments[type]({ pubkey: key, network: networkObj });
 }
 
-export function getDerivationPath(formatType:AddressFormats, accountIndex = 0 , index = 0 ){
+export function getDerivationPath(formatType: AddressFormats, accountIndex = 0, index = 0) {
   const pathFormat = {
     legacy: `m/44'/0'/${accountIndex}'/0/${index}`,
     segwit: `m/49'/0'/${accountIndex}'/0/${index}`,
     bech32: `m/84'/0'/${accountIndex}'/0/${index}`,
     taproot: `m/86'/0'/${accountIndex}'/0/${index}`
-  }
-  return pathFormat[formatType]
-
+  };
+  return pathFormat[formatType];
 }
 
-export function getPathLevels(fullDerivationPath: string){
-  const [, purpose, coinType, account,change,addressIndex] = fullDerivationPath.split("/")
+export function getPathLevels(fullDerivationPath: string) {
+  const [, purpose, coinType, account, change, addressIndex] = fullDerivationPath.split("/");
   return {
     purpose: purpose.replace("'", ""),
     coinType: coinType.replace("'", ""),
-    account: account.replace("'",""),
+    account: account.replace("'", ""),
     change,
     addressIndex
-  }
+  };
 }
 
-export function hdNodeToChild(node: BIP32Interface, formatType: AddressFormats = "legacy", index = 0, accountIndex= 0) {
-  const fullDerivationPath = getDerivationPath(formatType, accountIndex, index)
+export function hdNodeToChild(
+  node: BIP32Interface,
+  formatType: AddressFormats = "legacy",
+  index = 0,
+  accountIndex = 0
+) {
+  const fullDerivationPath = getDerivationPath(formatType, accountIndex, index);
 
   return node.derivePath(fullDerivationPath);
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -38,8 +38,30 @@ export function createTransaction(
   return bitcoin.payments[type]({ pubkey: key, network: networkObj });
 }
 
-export function hdNodeToChild(node: BIP32Interface, formatType: AddressFormats = "legacy", index = 0) {
-  const fullDerivationPath = DERIVATION_PATHS_WITHOUT_INDEX[formatType] + index;
+export function getDerivationPath(formatType:AddressFormats, accountIndex = 0 , index = 0 ){
+  const pathFormat = {
+    legacy: `m/44'/0'/${accountIndex}'/0/${index}`,
+    segwit: `m/49'/0'/${accountIndex}'/0/${index}`,
+    bech32: `m/84'/0'/${accountIndex}'/0/${index}`,
+    taproot: `m/86'/0'/${accountIndex}'/0/${index}`
+  }
+  return pathFormat[formatType]
+
+}
+
+export function getPathLevels(fullDerivationPath: string){
+  const [, purpose, coinType, account,change,addressIndex] = fullDerivationPath.split("/")
+  return {
+    purpose: purpose.replace("'", ""),
+    coinType: coinType.replace("'", ""),
+    account: account.replace("'",""),
+    change,
+    addressIndex
+  }
+}
+
+export function hdNodeToChild(node: BIP32Interface, formatType: AddressFormats = "legacy", index = 0, accountIndex= 0) {
+  const fullDerivationPath = getDerivationPath(formatType, accountIndex, index)
 
   return node.derivePath(fullDerivationPath);
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -38,34 +38,23 @@ export function createTransaction(
   return bitcoin.payments[type]({ pubkey: key, network: networkObj });
 }
 
-export function getDerivationPath(formatType: AddressFormats, accountIndex = 0, index = 0) {
+export function getDerivationPath(formatType: AddressFormats, account = 0, addressIndex = 0) {
   const pathFormat = {
-    legacy: `m/44'/0'/${accountIndex}'/0/${index}`,
-    segwit: `m/49'/0'/${accountIndex}'/0/${index}`,
-    bech32: `m/84'/0'/${accountIndex}'/0/${index}`,
-    taproot: `m/86'/0'/${accountIndex}'/0/${index}`
+    legacy: `m/44'/0'/${account}'/0/${addressIndex}`,
+    segwit: `m/49'/0'/${account}'/0/${addressIndex}`,
+    bech32: `m/84'/0'/${account}'/0/${addressIndex}`,
+    taproot: `m/86'/0'/${account}'/0/${addressIndex}`
   };
   return pathFormat[formatType];
-}
-
-export function getPathLevels(fullDerivationPath: string) {
-  const [, purpose, coinType, account, change, addressIndex] = fullDerivationPath.split("/");
-  return {
-    purpose: purpose.replace("'", ""),
-    coinType: coinType.replace("'", ""),
-    account: account.replace("'", ""),
-    change,
-    addressIndex
-  };
 }
 
 export function hdNodeToChild(
   node: BIP32Interface,
   formatType: AddressFormats = "legacy",
-  index = 0,
-  accountIndex = 0
+  addressIndex = 0,
+  account = 0
 ) {
-  const fullDerivationPath = getDerivationPath(formatType, accountIndex, index);
+  const fullDerivationPath = getDerivationPath(formatType, account, addressIndex);
 
   return node.derivePath(fullDerivationPath);
 }

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -145,15 +145,15 @@ export class Ordit {
     }
   }
 
-  getAddress(type: AddressFormats, accountIndex: number, addressIndex: number) {
+  generateAddress(type: AddressFormats, account: number, addressIndex: number) {
     if (!this.#hdNode) throw new Error("No HD node found. Please reinitialize with BIP39 words or seed.");
 
     return getAccountDataFromHdNode({
       hdNode: this.#hdNode,
       format: type,
       network: this.#network,
-      accountIndex,
-      index: addressIndex
+      account,
+      addressIndex
     });
   }
 

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -145,10 +145,16 @@ export class Ordit {
     }
   }
 
-  getAddress(type: AddressFormats, accountIndex: number, addressIndex:number) {
+  getAddress(type: AddressFormats, accountIndex: number, addressIndex: number) {
     if (!this.#hdNode) throw new Error("No HD node found. Please reinitialize with BIP39 words or seed.");
 
-    return getAccountDataFromHdNode({ hdNode: this.#hdNode, format: type, network: this.#network, accountIndex, index:addressIndex });
+    return getAccountDataFromHdNode({
+      hdNode: this.#hdNode,
+      format: type,
+      network: this.#network,
+      accountIndex,
+      index: addressIndex
+    });
   }
 
   signPsbt(value: string, { finalized = true }: { finalized?: boolean }) {

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -37,7 +37,6 @@ export class Ordit {
   #hdNode: BIP32Interface | null = null;
   publicKey: string;
   allAddresses: ReturnType<typeof getAddressesFromPublicKey> | ReturnType<typeof getAllAccountsFromHdNode> = [];
-  currentAccountIndex: number | undefined
   selectedAddressType: AddressFormats | undefined;
   selectedAddress: string | undefined;
 

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -37,6 +37,7 @@ export class Ordit {
   #hdNode: BIP32Interface | null = null;
   publicKey: string;
   allAddresses: ReturnType<typeof getAddressesFromPublicKey> | ReturnType<typeof getAllAccountsFromHdNode> = [];
+  currentAccountIndex: number | undefined
   selectedAddressType: AddressFormats | undefined;
   selectedAddress: string | undefined;
 
@@ -145,19 +146,10 @@ export class Ordit {
     }
   }
 
-  addAddress(type: AddressFormats, count = 1) {
+  getAddress(type: AddressFormats, accountIndex: number, addressIndex:number) {
     if (!this.#hdNode) throw new Error("No HD node found. Please reinitialize with BIP39 words or seed.");
 
-    const accounts: Account[] = [];
-    for (let i = 0; i < count; i++) {
-      const account = getAccountDataFromHdNode({ hdNode: this.#hdNode, format: type, network: this.#network });
-
-      accounts.push(account);
-    }
-
-    this.allAddresses.push(...accounts);
-
-    return accounts;
+    return getAccountDataFromHdNode({ hdNode: this.#hdNode, format: type, network: this.#network, accountIndex, index:addressIndex });
   }
 
   signPsbt(value: string, { finalized = true }: { finalized?: boolean }) {


### PR DESCRIPTION
This PR refactors the way new addresses are generated by relying on explicitly provided path levels.

1. Renamed `addAddress`  to `generateAddress`
2. Extended `generateAddress` to generate new address based on the following provided path levels:
    - `account`
    - `addressIndex`
4. Add types

Breaking change: 
- `generateAddress` bypasses the `allAddresses` store on the `Ordit` class -- meaning newly generated addresses are not tracked which at this point may break recently introduced instant-buy feature.