### PR TITLE
fix(sdk): add missing meta property to inscription object

### DIFF
--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -163,6 +163,7 @@ export interface InscriptionsEntity {
   media_type: string;
   media_size: number;
   media_content: string;
+  meta?: Record<string,any>
 }
 
 export interface InscriptionDetailsEntity {

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -163,7 +163,7 @@ export interface InscriptionsEntity {
   media_type: string;
   media_size: number;
   media_content: string;
-  meta?: Record<string,any>
+  meta?: Record<string, any>;
 }
 
 export interface InscriptionDetailsEntity {


### PR DESCRIPTION
This PR adds the missing optional `meta` property to `InscriptionsEntity` interface.

As per [OIP-1](https://github.com/sadoprotocol/oips/blob/main/oip-01-inscription-metadata.md), the `meta` object is returned by the [utxo/unspents](https://github.com/sadoprotocol/utxo-api/blob/a2cb353a1ef80c77307af2915b8b10d195d4c144/src/lookup.js#L126-L143) endpoint.
