### PR TITLE
fix(sdk): handle undefined spendables

### DIFF
--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -15,6 +15,12 @@ export async function createPsbt({ network, format, pubKey, ins, outs }: CreateP
     network
   });
 
+  if (walletWithBalances?.spendables === undefined) {
+    throw new Error(
+      "The derived wallet doesn't contain any spendable sats. It may be empty or contain sats that are either linked to inscriptions or tied to ordinals."
+    );
+  }
+
   let fees = 0;
   let change = 0;
   const dust = 600;
@@ -43,10 +49,6 @@ export async function createPsbt({ network, format, pubKey, ins, outs }: CreateP
   });
 
   ins.forEach((input, idx) => {
-    if (walletWithBalances?.spendables === undefined) {
-      throw new Error("No spendables available.");
-    }
-
     if (input.address) {
       walletWithBalances.spendables.forEach((spendable: any) => {
         const sats = spendable.sats;

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -43,7 +43,7 @@ export async function createPsbt({ network, format, pubKey, ins, outs }: CreateP
   });
 
   ins.forEach((input, idx) => {
-    if (walletWithBalances.spendables === undefined) {
+    if (walletWithBalances?.spendables === undefined) {
       throw new Error("No spendables available.");
     }
 

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -43,6 +43,10 @@ export async function createPsbt({ network, format, pubKey, ins, outs }: CreateP
   });
 
   ins.forEach((input, idx) => {
+    if (walletWithBalances.spendables === undefined) {
+      throw new Error("No spendables available.");
+    }
+
     if (input.address) {
       walletWithBalances.spendables.forEach((spendable: any) => {
         const sats = spendable.sats;


### PR DESCRIPTION
`spendables` can be `undefined` when the wallet has no cardinals

https://github.com/sadoprotocol/ordit-sdk/blob/6f0391bca8bbb25c705c24213ad929ad682b8dc5/packages/sdk/src/transactions/psbt.ts#L47

`Error: Cannot read properties of undefined (reading 'forEach')`

This fix checks if `spendables` is defined before attempting to loop through the array.

Fixes #11 