### PR TITLE
feat(psbt): allow custom fee rate in `createPsbt`

### DIFF
--- a/examples/node/send.js
+++ b/examples/node/send.js
@@ -3,6 +3,7 @@ import { ordit } from "@sadoprotocol/ordit-sdk"; //import Ordit
 async function main() {
   // Replace accordingly
   const psbtTemplate = {
+    satsPerByte: 1,
     format: "p2wpkh",
     network: "testnet",
     pubKey: "02950611fedb407d34cc845101f2bdfb2e7e3ec075e1424015bbf2db75c8ebe696",

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -5,7 +5,15 @@ import { Network, Psbt } from "bitcoinjs-lib";
 import { createTransaction, getNetwork } from "../utils";
 import { GetWalletOptions, getWalletWithBalances } from "../wallet";
 
-export async function createPsbt({ network, format, pubKey, ins, outs, safeMode = "on" }: CreatePsbtOptions) {
+export async function createPsbt({
+  network,
+  format,
+  pubKey,
+  ins,
+  outs,
+  safeMode = "on",
+  satsPerByte
+}: CreatePsbtOptions) {
   const netWorkObj = getNetwork(network);
   const bip32 = BIP32Factory(ecc);
 
@@ -26,7 +34,7 @@ export async function createPsbt({ network, format, pubKey, ins, outs, safeMode 
   let change = 0;
   const dust = 600;
   let inputs_used = 0;
-  const sats_per_byte = 10;
+  const sats_per_byte = satsPerByte ?? 10;
   let total_cardinals_to_send = 0;
   let total_cardinals_available = 0;
   const unsupported_inputs = [];
@@ -195,6 +203,7 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
 }
 
 export type CreatePsbtOptions = GetWalletOptions & {
+  satsPerByte?: number;
   ins: any[];
   outs: any[];
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Let the consumer specify a custom fee rate (sats per byte) when creating a PSBT. (Optional)