### PR TITLE
refactor(sdk)!: dynamic fee calculation and improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "printWidth": 120,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "semi": false
 }

--- a/examples/node/collections.js
+++ b/examples/node/collections.js
@@ -58,7 +58,7 @@ async function publish() {
 
     // sign transaction
     const psbtHex = transaction.toHex();
-    const sig = wallet.signPsbt(psbtHex, { finalized: true });
+    const sig = wallet.signPsbt(psbtHex, { isRevealTx: true });
     // console.log(JSON.stringify(sig, null, 2))
     // Broadcast transaction
     const submittedTx = await wallet.relayTx(sig, "testnet");
@@ -117,7 +117,7 @@ async function mint() {
 
     // sign transaction
     const psbtHex = transaction.toHex();
-    const sig = userWallet.signPsbt(psbtHex, { finalized: true });
+    const sig = userWallet.signPsbt(psbtHex, { isRevealTx: true });
     // console.log(JSON.stringify(sig, null, 2))
     // Broadcast transaction
     const submittedTx = await userWallet.relayTx(sig, "testnet");

--- a/examples/node/collections.js
+++ b/examples/node/collections.js
@@ -1,8 +1,6 @@
 import { Ordit } from "@sadoprotocol/ordit-sdk";
-import { base64_encode } from "./utils.js";
 
 const WORDS = "<MNEMONIC PHRASE>";
-const IMG_BASE64 = base64_encode("./assets/collection/cover.png"); // relative path to image
 
 async function publish() {
   // Load wallet
@@ -16,15 +14,15 @@ async function publish() {
 
   //publish
   const transaction = await Ordit.collection.publish({
-    title: "Elemental",
-    description: "Azuki Elementals are a collection of 20,000 characters within the four domains of the Garden.",
-    slug: "elemental",
+    title: "Collection Name",
+    description: "Lorem ipsum something else",
+    slug: "collection-name",
     creator: {
       address: wallet.selectedAddress,
-      email: "iamsaikranthi@gmail.com",
-      name: "Sai Kranthi"
+      email: "your-email@example.com",
+      name: "Your Name"
     },
-    publishers: ["n4PnWbQRkn4XxcYjsSao97D5Xx96SYAvLw"],
+    publishers: ["<publisher-legacy-address>"],
     inscriptions: [
       {
         iid: "el-01",
@@ -37,13 +35,13 @@ async function publish() {
         sri: "sha256-zjQXDuk++5sICrObmfWqAM5EibidXd2emZoUcU2l5Pg="
       }
     ],
-    url: "https://google.com",
+    url: "https://example.com",
     publicKey: wallet.publicKey,
     destination: wallet.selectedAddress,
     changeAddress: wallet.selectedAddress,
     postage: 1000,
-    mediaContent: IMG_BASE64,
-    mediaType: "image/png"
+    mediaContent: 'Collection Name', // this will be inscribed on-chain as primary content
+    mediaType: "text/plain"
   });
 
   const depositDetails = transaction.generateCommit();

--- a/examples/node/create-psbt.js
+++ b/examples/node/create-psbt.js
@@ -21,7 +21,7 @@ async function main() {
 
     wallet.setDefaultAddress('taproot')
 
-    const signature = await wallet.signPsbt(psbt.hex, { finalized: true, tweak: true })
+    const signature = await wallet.signPsbt(psbt.hex)
     const txResponse = await wallet.relayTx(signature, 'testnet')
 
     console.log("tx >>", txResponse)

--- a/examples/node/create-psbt.js
+++ b/examples/node/create-psbt.js
@@ -13,9 +13,9 @@ async function main() {
         network: 'testnet'
     })
 
-    const WORDS = "caution curtain there off know kit market gather slim april dutch sister"; // Generated HD wallet seed phrase
+    const MNEMONIC = "<MNEMONIC>"; // Generated HD wallet seed phrase
     const wallet = new Ordit({
-        bip39: WORDS,
+        bip39: MNEMONIC,
         network: "testnet"
     });
 

--- a/examples/node/create-psbt.js
+++ b/examples/node/create-psbt.js
@@ -1,6 +1,14 @@
 import { Ordit, ordit } from '@sadoprotocol/ordit-sdk'
 
 async function main() {
+    const MNEMONIC = "<MNEMONIC>"; // Generated HD wallet seed phrase
+    const wallet = new Ordit({
+        bip39: MNEMONIC,
+        network: "testnet"
+    });
+
+    wallet.setDefaultAddress('taproot')
+
     const psbt = await ordit.transactions.createPsbt({
         pubKey: '039ce27aa7666731648421004ba943b90b8273e23a175d9c58e3ec2e643a9b01d1',
         ins: [{
@@ -10,16 +18,10 @@ async function main() {
             address: 'tb1qatkgzm0hsk83ysqja5nq8ecdmtwl73zwurawww',
             cardinals: 1200
         }],
-        network: 'testnet'
+        network: 'testnet',
+        satsPerByte: 9,
+        format: 'p2tr'
     })
-
-    const MNEMONIC = "<MNEMONIC>"; // Generated HD wallet seed phrase
-    const wallet = new Ordit({
-        bip39: MNEMONIC,
-        network: "testnet"
-    });
-
-    wallet.setDefaultAddress('taproot')
 
     const signature = await wallet.signPsbt(psbt.hex)
     const txResponse = await wallet.relayTx(signature, 'testnet')

--- a/examples/node/inscribe.js
+++ b/examples/node/inscribe.js
@@ -45,7 +45,7 @@ async function main() {
     transaction.build();
 
     // sign transaction
-    const signature = wallet.signPsbt(transaction.toHex(), { finalized: true });
+    const signature = wallet.signPsbt(transaction.toHex());
 
     // Broadcast transaction
     const tx = await wallet.relayTx(signature, "testnet");

--- a/examples/node/inscribe.js
+++ b/examples/node/inscribe.js
@@ -1,79 +1,55 @@
-import { Ordit } from "@sadoprotocol/ordit-sdk"; //import Ordit
-import { base64_encode } from "./utils";
+import { Ordit } from "@sadoprotocol/ordit-sdk"
 
-const WORDS = "<MNEMONIC WORDS>"; // Generated HD wallet seed phrase
-const IMG_BASE64 = base64_encode("./azuki-small-compressed.png"); // relative path to image
+const MNEMONIC = "caution curtain there off know kit market gather slim april dutch sister"
 
 async function main() {
-  // Load wallet
+  // init wallet
   const wallet = new Ordit({
-    bip39: WORDS,
-    network: "mainnet"
+    bip39: MNEMONIC,
+    network: "testnet"
   });
 
-  // new ordinal transaction
+  wallet.setDefaultAddress('taproot')
+
+  // new inscription tx
   const transaction = Ordit.inscription.new({
-    publicKey: wallet.taprootPublicKey,
+    network: "testnet",
+    publicKey: wallet.publicKey,
     changeAddress: wallet.selectedAddress,
     destination: wallet.selectedAddress,
-    mediaContent: IMG_BASE64,
+    mediaContent: 'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAsTAAALEwEAmpwYAAADGElEQVR4nO2by04UQRSGvw34CjoGDAQ3XhDXRnTBAiG4ExMn8QlMmHh5ghE2OOMTsOPmgkSJuhiIuNCVvgFGRia6YFxoNPEGjClyOjlpZyKMU101dn1Jp5Pups7pw+mqv07VQCAQCARaTg9wDcgDc8AjYEXOc3I9C/TyH3EamAbKQO0Ah3n+HtBPmzIIlBq83DawAbwGXsp5Q67Xe74k7bUFR4CF2AvsAGtADjgLdDb42065n5Pnd2LtLAIZPOYSsKUc/grcB4412V43UAS+qDarwAgechPYVY4utPC/ZdqZV20bO7fwiLxy7jNw1ZKdcWk/sjWFB9xQDn0Azli2dwLYVDbv4Pib3xVH3ss4nwSmT6moz2EUR739lkr7UwnbP6k+h6qL0WFRpaFRby64EhsiE2Mw1tu7RI8OF5MyWlLjvGthclT8MP6sJqXta3IYkeIDReXTgG1j00reNqvwWk23ks0F28bKYshodZ94Jn69s2mkR6WambD4RE751mfLSFYZMbM2nxhQvl23rfm3gUP4RQfwU/y7a8vIrBh4i5+8Ef+MNrDCshgwFRwfeSX+PbYtgF7gJ8/FPzMiWGE57Rkwm/Y+IK9GgUaFTR9GgUlbRrJp1wG9baIEj9s0VE7zXCA+GzSzMB/oUrNBsw5hlX6VatannvukkGQ9wLeKUEZVhBL7LC+oiFsbc5uoCZ53VRUex31VeMlF6lXVuoCp0yeJWSH6JPY/AodxwIhaGaokWCPsUstjpvcfwyG3VRpWEsiE+NrgDB4wFVsdHrf4zUdpHx3fXa0N1ssEvT9gvsX7A+ZiO05m5OW9CsKo6hgjnVD8B8XYJSInGuejDm9M2fMuCBngQYM9QhOyf8BMXevRIfcnRNvH9wgt1entvQxCJJZWG+z6+gWsS2VpRc7rcr3e82t/ETneBgHR5gWZpdUOcGzKxGa/2t7rIET0SbFiUjrJJ5IBT6WTm5T7zc7n2yIIthkGvkkQfgCXSSHDIQiEIBhCJhCCsEfIBEIQ9giZwJ9iaYiUB+EhKWVIfqx1zrUjgUAggG/8BsfNc0SX+zvYAAAAAElFTkSuQmCC',
     mediaType: "image/png",
     feeRate: 15,
-    meta: {
-      title: "Elemental",
-      desc: "Azuki Elementals are a collection of 20,000 characters within the four domains of the Garden.",
-      slug: "elemental",
-      traits: [
-        {
-          traitType: "Hair",
-          value: "Electrified Long - Black"
-        },
-        {
-          traitType: "Offhand",
-          value: "Elemental Blade - Lightning"
-        },
-        {
-          traitType: "Eyes",
-          value: "Enticing"
-        },
-        {
-          traitType: "Type",
-          value: "Blue"
-        }
-      ],
+    meta: { // Flexible object: Record<string, any>
+      title: "Example title",
+      desc: "Lorem ipsum",
+      slug: "cool-digital-artifact",
       creator: {
-        name: "TheArtist",
+        name: "Your Name",
         email: "artist@example.org",
         address: wallet.selectedAddress
       }
     },
-    network: "mainnet",
-    postage: 1500
-  });
+    postage: 1500 // base value of the inscription in sats
+  })
 
-  //   //   Get deposit address and fee for inscription
-  const depositDetails = transaction.generateCommit();
-  console.log(depositDetails);
-  //   // {
-  //   //   address: "<DEPOSIT_ADDRESS>",
-  //   //   revealFee: 23456,
-  //   // }
+  // generate deposit address and fee for inscription
+  const revealed = transaction.generateCommit();
+  console.log(revealed) // deposit revealFee to address
 
-  //   // confirm if deposit address has been funded
-  const ready = await transaction.isReady(); //- true/false
+  // confirm if deposit address has been funded
+  const ready = await transaction.isReady();
 
   if (ready || transaction.ready) {
     // build transaction
     transaction.build();
 
     // sign transaction
-    const psbtHex = transaction.toHex();
-    const sig = wallet.signPsbt(psbtHex);
-    // console.log(JSON.stringify(sig, null, 2))
+    const signature = wallet.signPsbt(transaction.toHex(), { finalized: true });
+
     // Broadcast transaction
-    const submittedTx = await wallet.relayTx(sig.hex, "mainnet");
-    console.log(submittedTx);
-    //{"txid": "<TX_ID>"}
+    const tx = await wallet.relayTx(signature, "testnet");
+    console.log(tx);
   }
 }
 

--- a/examples/node/inscribe.js
+++ b/examples/node/inscribe.js
@@ -1,6 +1,6 @@
 import { Ordit } from "@sadoprotocol/ordit-sdk"
 
-const MNEMONIC = "caution curtain there off know kit market gather slim april dutch sister"
+const MNEMONIC = "<MNEMONIC>"
 
 async function main() {
   // init wallet

--- a/examples/node/instant-buy.js
+++ b/examples/node/instant-buy.js
@@ -47,7 +47,7 @@ async function createBuyOrder({ sellerPSBT }) {
         inscriptionOutPoint: '0f3891f61b944c31fb48b0d9e770dc9e66a4b49097027be53b078be67aca72d4:0'
     })
     
-    const signature = buyerWallet.signPsbt(buyerPSBT.toHex(), { finalized: true, extractTx: true })
+    const signature = buyerWallet.signPsbt(buyerPSBT.toHex())
     const tx = await buyerWallet.relayTx(signature, 'testnet')
 
     return tx

--- a/examples/node/instant-buy.js
+++ b/examples/node/instant-buy.js
@@ -1,0 +1,88 @@
+import { OrditApi, Ordit } from '@sadoprotocol/ordit-sdk'
+
+const BUYER_MNEMONIC = `<12-WORDS-PHRASE>`
+const SELLER_MNEMONIC = `<12-WORDS-PHRASE>`
+
+// Initialise seller wallet
+const sellerWallet = new Ordit({
+    bip39: SELLER_MNEMONIC,
+    network: 'testnet'
+})
+sellerWallet.setDefaultAddress('taproot') // Switch to address that owns inscription
+
+// Initialise buyer wallet
+const buyerWallet = new Ordit({
+    bip39: BUYER_MNEMONIC,
+    network: 'testnet'
+})
+
+// Switch to address that has enough BTC to cover the sell price + network fees
+buyerWallet.setDefaultAddress('taproot') 
+
+async function createSellOrder() {
+    // replace w/ inscription outputpoint you'd like to sell, price, and address to receive sell proceeds
+    const sellerPSBT = await Ordit.instantBuy.generateSellerPsbt({
+        inscriptionOutPoint: '8d4a576aecb33b809c208d672a43fd6b175478d9454df4455ed0a2dc7eb7cbf6:0', 
+        price: 4000, // Total sale proceeds will be price + inscription output value (4000 + 2000 = 6000 sats)
+        receiveAddress: sellerWallet.selectedAddress,
+        pubKeyType: sellerWallet.selectedAddressType,
+        publicKey: sellerWallet.publicKey,
+        network: 'testnet'
+    })
+
+    const signedSellerPSBT = sellerWallet.signPsbt(sellerPSBT.toHex(), { finalize: false, extractTx: false })
+
+    return signedSellerPSBT // hex
+}
+
+async function createBuyOrder({ sellerPSBT }) {    
+    await checkForExistingRefundableUTXOs(buyerWallet.selectedAddress)
+
+    const buyerPSBT = await Ordit.instantBuy.generateBuyerPsbt({
+        sellerPsbt: sellerPSBT,
+        publicKey: buyerWallet.publicKey,
+        pubKeyType: buyerWallet.selectedAddressType,
+        feeRate: 10, // set correct rate to prevent tx from getting stuck in mempool
+        network: 'testnet',
+        inscriptionOutPoint: '0f3891f61b944c31fb48b0d9e770dc9e66a4b49097027be53b078be67aca72d4:0'
+    })
+    
+    const signature = buyerWallet.signPsbt(buyerPSBT.toHex(), { finalized: true, extractTx: true })
+    const tx = await buyerWallet.relayTx(signature, 'testnet')
+
+    return tx
+}
+
+async function checkForExistingRefundableUTXOs(address) {
+    const response = await OrditApi.fetch('/utxo/unspents', {
+        data: {
+            address: address,
+            options: {
+                txhex: true,
+                notsafetospend: false,
+                allowedrarity: ["common"]
+            }
+        },
+        network: 'testnet'
+    })
+
+    const utxos = response.rdata
+    const filteredUTXOs = utxos
+        .filter(utxo => utxo.safeToSpend && !utxo.inscriptions.length && utxo.sats > 600 && utxo.sats <= 1000)
+        .sort((a, b) => a.sats - b.sats) // Sort by lowest value utxo to highest such that we spend only the ones that are lowest
+
+    if(filteredUTXOs.length < 2) {
+        throw new Error("Not enough UTXOs in 600-1000 sats range. Use Ordit.instantBuy.generateDummyUtxos() to generate dummy utxos.")
+    }
+}
+
+async function main() {
+    const signedSellerPSBT = await createSellOrder()
+    const tx = await createBuyOrder({ sellerPSBT: signedSellerPSBT })
+
+    console.log(tx) // 6dc768015dda40c3752bfc011077ae9b1445d0c9cb5b385fda6ee26dab6cb267
+}
+
+;(async() => {
+    await main()
+})()

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -8,7 +8,8 @@
     "inscribe": "node inscribe",
     "read": "node read",
     "send": "node send",
-    "create-psbt": "node create-psbt"
+    "create-psbt": "node create-psbt",
+    "instant-buy": "node instant-buy"
   },
   "author": "",
   "license": "ISC",

--- a/examples/node/utils.js
+++ b/examples/node/utils.js
@@ -1,9 +1,0 @@
-import fs from "fs";
-
-//Utility methods
-export function base64_encode(file) {
-  // read binary data
-  var bitmap = fs.readFileSync(file);
-  // convert binary data to base64 encoded string
-  return Buffer.from(bitmap).toString("base64");
-}

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -20,13 +20,21 @@ export class OrditApi {
       throw new Error('Invalid address')
     }
 
-    const utxos = await rpc[network].call<UTXO[]>('GetUnspents', { 
-      address, 
-      options: {
-        allowedrarity: rarity,
-        safetospend: type === "spendable",
-      }
-    }, rpc.id)
+    const utxos = await rpc[network].call<UTXO[]>(
+      "GetUnspents",
+      {
+        address,
+        options: {
+          allowedrarity: rarity,
+          safetospend: type === "spendable"
+        },
+        pagination: {
+          page: 1,
+          limit: 25
+        }
+      },
+      rpc.id
+    )
 
     const { spendableUTXOs, unspendableUTXOs } = utxos.reduce((acc, utxo) => {
       if(utxo.inscriptions?.length && !utxo.safeToSpend) {

--- a/packages/sdk/src/browser-wallets/unisat/index.ts
+++ b/packages/sdk/src/browser-wallets/unisat/index.ts
@@ -1,3 +1,4 @@
-export * from "./addresses";
-export * from "./signatures";
-export * from "./utils";
+export * from "./addresses"
+export * from "./signatures"
+export * from "./types"
+export * from "./utils"

--- a/packages/sdk/src/browser-wallets/unisat/index.ts
+++ b/packages/sdk/src/browser-wallets/unisat/index.ts
@@ -1,4 +1,3 @@
 export * from "./addresses"
 export * from "./signatures"
-export * from "./types"
 export * from "./utils"

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -2,14 +2,14 @@ import { Psbt } from "bitcoinjs-lib";
 
 import { isUnisatInstalled } from "./utils";
 
-export async function signPsbt(psbt: Psbt) {
+export async function signPsbt(psbt: Psbt, { finalize = true }: UnisatSignPSBTOptions = {}) {
   if (!isUnisatInstalled()) {
     throw new Error("Unisat not installed.");
   }
 
   const psbtHex = psbt.toHex();
 
-  const signedPsbtHex = await window.unisat.signPsbt(psbtHex);
+  const signedPsbtHex = await window.unisat.signPsbt(psbtHex, { autoFinalized: finalize })
 
   if (!signedPsbtHex) {
     throw new Error("Failed to sign psbt hex using Unisat.");

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -1,6 +1,6 @@
 import { Psbt } from "bitcoinjs-lib";
 
-import { isUnisatInstalled } from "./utils";
+import { UnisatSignPSBTOptions } from "./types"
 
 export async function signPsbt(psbt: Psbt, { finalize = true }: UnisatSignPSBTOptions = {}) {
   if (!isUnisatInstalled()) {

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -1,6 +1,7 @@
 import { Psbt } from "bitcoinjs-lib";
 
 import { UnisatSignPSBTOptions } from "./types"
+import { isUnisatInstalled } from "./utils"
 
 export async function signPsbt(psbt: Psbt, { finalize = true }: UnisatSignPSBTOptions = {}) {
   if (!isUnisatInstalled()) {

--- a/packages/sdk/src/browser-wallets/unisat/types.ts
+++ b/packages/sdk/src/browser-wallets/unisat/types.ts
@@ -1,0 +1,3 @@
+export interface UnisatSignPSBTOptions {
+  finalize?: boolean
+}

--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -1,0 +1,3 @@
+// amount lower than this is considered as dust value
+// and majority of the miners don't pick txs w/ the following output value or lower
+export const MINIMUM_AMOUNT_IN_SATS = 600

--- a/packages/sdk/src/inscription/commit.ts
+++ b/packages/sdk/src/inscription/commit.ts
@@ -1,44 +1,44 @@
-import { getAddresses } from "../addresses";
-import { createTransaction } from "../utils";
-import { GetWalletOptions } from "../wallet";
-import { buildWitnessScript } from "./witness";
+import { getAddresses } from "../addresses"
+import { createTransaction } from "../utils"
+import { GetWalletOptions } from "../wallet"
+import { buildWitnessScript } from "./witness"
 
 export async function generateCommitAddress(options: GenerateCommitAddressOptions) {
-  const { satsPerByte = 10, network, pubKey } = options;
-  const key = (await getAddresses({ pubKey, network, format: "p2tr" }))[0];
-  const xkey = key.xkey;
+  const { satsPerByte = 10, network, pubKey } = options
+  const key = (await getAddresses({ pubKey, network, format: "p2tr" }))[0]
+  const xkey = key.xkey
 
   if (xkey) {
-    const witnessScript = buildWitnessScript({ ...options, xkey });
+    const witnessScript = buildWitnessScript({ ...options, xkey })
 
     if (!witnessScript) {
-      throw new Error("Failed to build witness script.");
+      throw new Error("Failed to build witness script.")
     }
 
     const scriptTree = {
       output: witnessScript
-    };
+    }
 
     const p2tr = createTransaction(Buffer.from(xkey, "hex"), "p2tr", options.network, {
       scriptTree
-    });
+    })
 
-    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * satsPerByte));
-    const scriptLength = witnessScript.toString("hex").length;
-    const scriptFees = (scriptLength / 10) * satsPerByte + fees;
+    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * satsPerByte))
+    const scriptLength = witnessScript.toString("hex").length
+    const scriptFees = (scriptLength / 10) * satsPerByte + fees
 
     return {
       address: p2tr.address,
       xkey,
       format: "inscribe",
       fees: scriptFees
-    };
+    }
   }
 }
 
 export type GenerateCommitAddressOptions = Omit<GetWalletOptions, "format" | "safeMode"> & {
-  satsPerByte: number;
-  mediaType: string;
-  mediaContent: string;
-  meta: any;
-};
+  satsPerByte: number
+  mediaType: string
+  mediaContent: string
+  meta: any
+}

--- a/packages/sdk/src/inscription/commit.ts
+++ b/packages/sdk/src/inscription/commit.ts
@@ -23,7 +23,7 @@ export async function generateCommitAddress(options: GenerateCommitAddressOption
       scriptTree
     })
 
-    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * satsPerByte))
+    const fees = (80 + 1 * 180) * satsPerByte
     const scriptLength = witnessScript.toString("hex").length
     const scriptFees = (scriptLength / 10) * satsPerByte + fees
 

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -90,7 +90,8 @@ export async function generateBuyerPsbt({
   for (let i = 0; i < spendableUTXOs.length; i++) {
     const utxo = spendableUTXOs[i]
 
-    if (utxo.sats >= 580 && utxo.sats <= 1000) {
+    // TODO: move hardcoded value to constants
+    if (utxo.sats >= 600) {
       refundableUTXOs.push(utxo)
     }
   }

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -72,7 +72,7 @@ export async function generateBuyerPsbt({
       throw new Error("Outpoint not found.");
     }
 
-    postage = output.value * 1e8;
+    postage = parseInt((output.value * 1e8).toString());
   } catch (error) {
     throw new Error(error.message);
   }
@@ -155,7 +155,7 @@ export async function generateBuyerPsbt({
   // Add dummy output
   psbt.addOutput({
     address: address.address!,
-    value: dummyUtxos[0].sats + dummyUtxos[1].sats + ordOutNumber
+    value: dummyUtxos[0].sats + dummyUtxos[1].sats
   });
 
   // Add ordinal output

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -13,6 +13,7 @@ import {
   processInput
 } from ".."
 import { Network } from "../config/types"
+import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
 
 export async function generateSellerPsbt({
   inscriptionOutPoint,
@@ -90,8 +91,7 @@ export async function generateBuyerPsbt({
   for (let i = 0; i < spendableUTXOs.length; i++) {
     const utxo = spendableUTXOs[i]
 
-    // TODO: move hardcoded value to constants
-    if (utxo.sats >= 600) {
+    if (utxo.sats >= MINIMUM_AMOUNT_IN_SATS) {
       refundableUTXOs.push(utxo)
     }
   }
@@ -176,7 +176,7 @@ export async function generateBuyerPsbt({
 }
 
 export async function generateRefundableUTXOs({
-  value = 600,
+  value = MINIMUM_AMOUNT_IN_SATS,
   count = 2,
   publicKey,
   feeRate = 10,

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -30,7 +30,7 @@ export async function generateSellerPsbt({
     network
   });
 
-  const networkObj = getNetwork("testnet");
+  const networkObj = getNetwork(network)
   const psbt = new bitcoin.Psbt({ network: networkObj });
 
   psbt.addInput(inputs[0]);

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -19,7 +19,7 @@ export async function generateSellerPsbt({
   price,
   receiveAddress,
   publicKey,
-  pubKeyType = "taproot",
+  pubKeyType,
   network = "testnet"
 }: GenerateSellerInstantBuyPsbtOptions) {
   const { inputs, outputs } = await getSellerInputsOutputs({
@@ -42,7 +42,7 @@ export async function generateSellerPsbt({
 
 export async function generateBuyerPsbt({
   publicKey,
-  pubKeyType = "legacy",
+  pubKeyType,
   feeRate = 10,
   network = "testnet",
   sellerPsbt,
@@ -309,7 +309,7 @@ export interface GenerateSellerInstantBuyPsbtOptions {
 
 export interface GenerateBuyerInstantBuyPsbtOptions {
   publicKey: string
-  pubKeyType?: AddressFormats
+  pubKeyType: AddressFormats
   network?: Network
   feeRate?: number
   inscriptionOutPoint: string
@@ -320,7 +320,7 @@ export interface GenerateRefundableUTXOsOptions {
   value: number
   count: number
   publicKey: string
-  pubKeyType?: AddressFormats
+  pubKeyType: AddressFormats
   network?: Network
   feeRate?: number
 }

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -1,17 +1,19 @@
-import * as bitcoin from "bitcoinjs-lib";
+import * as bitcoin from "bitcoinjs-lib"
 
 import {
   AddressFormats,
   addressNameToType,
   AddressTypes,
+  calculateTxFee,
   calculateTxFeeWithRate,
   createTransaction,
   getAddressesFromPublicKey,
   getNetwork,
   OrditApi,
+  processInput,
   toXOnly
-} from "..";
-import { Network } from "../config/types";
+} from ".."
+import { Network } from "../config/types"
 
 export async function generateSellerPsbt({
   inscriptionOutPoint,
@@ -28,15 +30,15 @@ export async function generateSellerPsbt({
     publicKey,
     pubKeyType,
     network
-  });
+  })
 
   const networkObj = getNetwork(network)
-  const psbt = new bitcoin.Psbt({ network: networkObj });
+  const psbt = new bitcoin.Psbt({ network: networkObj })
 
-  psbt.addInput(inputs[0]);
-  psbt.addOutput(outputs[0]);
+  psbt.addInput(inputs[0])
+  psbt.addOutput(outputs[0])
 
-  return psbt;
+  return psbt
 }
 
 export async function generateBuyerPsbt({
@@ -47,142 +49,118 @@ export async function generateBuyerPsbt({
   sellerPsbt,
   inscriptionOutPoint
 }: GenerateBuyerInstantBuyPsbtOptions) {
-  const networkObj = getNetwork(network);
-  const format = addressNameToType[pubKeyType];
-  const address = getAddressesFromPublicKey(publicKey, network, format)[0];
-  let postage = 10000; // default postage
-  let ordOutNumber = 0;
+  const networkObj = getNetwork(network)
+  const format = addressNameToType[pubKeyType]
+  const address = getAddressesFromPublicKey(publicKey, network, format)[0]
+  let postage = 10000 // default postage
+  let ordOutNumber = 0
   // get postage from outpoint
 
   try {
-    const [ordTxId, ordOut] = inscriptionOutPoint.split(":");
+    const [ordTxId, ordOut] = inscriptionOutPoint.split(":")
     if (!ordTxId || !ordOut) {
-      throw new Error("Invalid outpoint.");
+      throw new Error("Invalid outpoint.")
     }
 
-    ordOutNumber = parseInt(ordOut);
+    ordOutNumber = parseInt(ordOut)
     const { tx } = await OrditApi.fetchTx({ txId: ordTxId, network })
     if (!tx) {
-      throw new Error("Failed to get raw transaction for id: " + ordTxId);
+      throw new Error("Failed to get raw transaction for id: " + ordTxId)
     }
 
-    const output = tx && tx.vout[ordOutNumber];
+    const output = tx && tx.vout[ordOutNumber]
 
     if (!output) {
-      throw new Error("Outpoint not found.");
+      throw new Error("Outpoint not found.")
     }
 
-    postage = parseInt((output.value * 1e8).toString());
+    postage = parseInt((output.value * 1e8).toString())
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.message)
   }
 
   const { totalUTXOs, spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ address: address.address!, network })
   if (!totalUTXOs) {
-    throw new Error("No UTXOs found.");
+    throw new Error("No UTXOs found.")
   }
 
-  const psbt = new bitcoin.Psbt({ network: networkObj });
-  const dummyUtxos = [];
+  const psbt = new bitcoin.Psbt({ network: networkObj })
+  const dummyUtxos = []
 
   //find dummy utxos
   for (let i = 0; i < spendableUTXOs.length; i++) {
-    const utxo = spendableUTXOs[i];
+    const utxo = spendableUTXOs[i]
 
     if (utxo.sats >= 580 && utxo.sats <= 1000) {
-      dummyUtxos.push(utxo);
+      dummyUtxos.push(utxo)
     }
   }
 
   if (dummyUtxos.length < 2 || !spendableUTXOs.length) {
-    throw new Error("No suitable UTXOs found.");
+    throw new Error("No suitable UTXOs found.")
   }
 
-  let totalInput = 0;
+  let totalInput = 0
 
   for (let i = 0; i < 2; i++) {
-    const dummyUtxo = dummyUtxos[i];
+    const dummyUtxo = dummyUtxos[i]
     const { rawTx } = await OrditApi.fetchTx({ txId: dummyUtxo.txid, network, hex: true })
     if (!rawTx) {
-      throw new Error("Failed to get raw transaction for id: " + dummyUtxo.txid);
+      throw new Error("Failed to get raw transaction for id: " + dummyUtxo.txid)
     }
 
     if (format !== "p2tr") {
       for (const output in rawTx.outs) {
         try {
-          rawTx.setWitness(parseInt(output), []);
+          rawTx.setWitness(parseInt(output), [])
         } catch {}
       }
     }
-    const input: any = {
-      hash: dummyUtxo.txid,
-      index: dummyUtxo.n,
-      nonWitnessUtxo: rawTx.toBuffer(),
-      sequence: 0xfffffffd // Needs to be at least 2 below max int value to be RBF
-    };
 
-    const p2shInputRedeemScript: any = {};
-    const p2shInputWitnessUTXO: any = {};
+    const p2shInputRedeemScript: any = {}
+    const p2shInputWitnessUTXO: any = {}
 
-    if (format === "p2sh") {
-      const p2sh = createTransaction(Buffer.from(publicKey, "hex"), format, network);
-      p2shInputWitnessUTXO.witnessUtxo = {
-        script: p2sh.output,
-        value: dummyUtxo.sats
-      };
-      p2shInputRedeemScript.redeemScript = p2sh.redeem?.output;
-    }
-
-    if (format === "p2tr") {
-      const xKey = toXOnly(Buffer.from(publicKey, "hex"));
-      const p2tr = createTransaction(xKey, "p2tr", network);
-
-      input.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"));
-      input.witnessUtxo = {
-        script: p2tr.output!,
-        value: dummyUtxo.sats
-      };
-    }
+    const input = processInput(dummyUtxo, publicKey, network)
 
     psbt.addInput({
       ...input,
       ...p2shInputWitnessUTXO,
       ...p2shInputRedeemScript
-    });
-    totalInput += dummyUtxo.sats;
+    })
+    totalInput += dummyUtxo.sats
   }
 
   // Add dummy output
   psbt.addOutput({
     address: address.address!,
     value: dummyUtxos[0].sats + dummyUtxos[1].sats
-  });
+  })
 
   // Add ordinal output
   psbt.addOutput({
     address: address.address!,
     value: postage
-  });
+  })
 
   // seller psbt merge
 
-  const decodedSellerPsbt = bitcoin.Psbt.fromHex(sellerPsbt, { network: networkObj });
+  const decodedSellerPsbt = bitcoin.Psbt.fromHex(sellerPsbt, { network: networkObj })
   // inputs
-  (psbt.data.globalMap.unsignedTx as any).tx.ins[2] = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.ins[0];
-  psbt.data.inputs[2] = decodedSellerPsbt.data.inputs[0];
+  ;(psbt.data.globalMap.unsignedTx as any).tx.ins[2] = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.ins[0]
+  psbt.data.inputs[2] = decodedSellerPsbt.data.inputs[0]
   // outputs
-  (psbt.data.globalMap.unsignedTx as any).tx.outs[2] = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.outs[0];
-  psbt.data.outputs[2] = decodedSellerPsbt.data.outputs[0];
+  ;(psbt.data.globalMap.unsignedTx as any).tx.outs[2] = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.outs[0]
+  psbt.data.outputs[2] = decodedSellerPsbt.data.outputs[0]
 
   for (let i = 0; i < spendableUTXOs.length; i++) {
-    const utxo = spendableUTXOs[i];
+    const utxo = spendableUTXOs[i]
 
     const { rawTx } = await OrditApi.fetchTx({ txId: utxo.txid, network, hex: true })
 
     if (format !== "p2tr") {
       for (const output in rawTx?.outs) {
         try {
-          rawTx.setWitness(parseInt(output), []);
+          rawTx.setWitness(parseInt(output), [])
         } catch {}
       }
     }
@@ -192,42 +170,49 @@ export async function generateBuyerPsbt({
       index: utxo.n,
       nonWitnessUtxo: rawTx?.toBuffer(),
       sequence: 0xfffffffd // Needs to be at least 2 below max int value to be RBF
-    };
+    }
 
     if (pubKeyType === "taproot") {
-      const xKey = toXOnly(Buffer.from(publicKey, "hex"));
-      const p2tr = createTransaction(xKey, "p2tr", network);
+      const xKey = toXOnly(Buffer.from(publicKey, "hex"))
+      const p2tr = createTransaction(xKey, "p2tr", network)
 
-      input.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"));
+      input.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"))
       input.witnessUtxo = {
         script: p2tr.output!,
         value: utxo.sats
-      };
+      }
     }
 
     psbt.addInput({
       ...input
-    });
+    })
 
-    totalInput += utxo.sats;
+    totalInput += utxo.sats
   }
 
-  const fee = calculateTxFeeWithRate(psbt.txInputs.length, psbt.txOutputs.length, feeRate);
-  const totalOutput = psbt.txOutputs.reduce((partialSum, a) => partialSum + a.value, 0);
+  // const fee = calculateTxFeeWithRate(psbt.txInputs.length, psbt.txOutputs.length, feeRate);
+  const fee = calculateTxFee({
+    totalInputs: psbt.txInputs.length,
+    totalOutputs: psbt.txOutputs.length,
+    satsPerByte: feeRate,
+    type: pubKeyType
+  })
 
-  const changeValue = totalInput - totalOutput - fee;
+  const totalOutput = psbt.txOutputs.reduce((partialSum, a) => partialSum + a.value, 0)
+
+  const changeValue = totalInput - totalOutput - fee
   if (changeValue < 0) {
-    throw new Error("Insufficient funds to buy this inscription");
+    throw new Error("Insufficient funds to buy this inscription")
   }
 
   if (changeValue > 580) {
     psbt.addOutput({
       address: address.address!,
       value: changeValue
-    });
+    })
   }
 
-  return psbt;
+  return psbt
 }
 
 export async function generateDummyUtxos({
@@ -238,56 +223,56 @@ export async function generateDummyUtxos({
   pubKeyType = "taproot",
   network = "testnet"
 }: GenerateDummyUtxos) {
-  const networkObj = getNetwork(network);
-  const format = addressNameToType[pubKeyType];
-  const address = getAddressesFromPublicKey(publicKey, network, format)[0];
+  const networkObj = getNetwork(network)
+  const format = addressNameToType[pubKeyType]
+  const address = getAddressesFromPublicKey(publicKey, network, format)[0]
 
   const { totalUTXOs, spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ address: address.address!, network })
   if (!totalUTXOs) {
-    throw new Error("No UTXOs found.");
+    throw new Error("No UTXOs found.")
   }
 
-  const psbt = new bitcoin.Psbt({ network: networkObj });
-  let totalValue = 0;
-  let paymentUtxoCount = 0;
+  const psbt = new bitcoin.Psbt({ network: networkObj })
+  let totalValue = 0
+  let paymentUtxoCount = 0
 
   for (let i = 0; i < spendableUTXOs.length; i++) {
-    const utxo = spendableUTXOs[i];
+    const utxo = spendableUTXOs[i]
     const { rawTx } = await OrditApi.fetchTx({ txId: utxo.txid, network, hex: true })
     if (!rawTx) {
-      throw new Error("Failed to get raw transaction for id: " + utxo.txid);
+      throw new Error("Failed to get raw transaction for id: " + utxo.txid)
     }
 
     const input: any = {
       hash: utxo.txid,
       index: utxo.n,
       nonWitnessUtxo: rawTx.toBuffer(),
-      sequence: 0xfffffffd, // Needs to be at least 2 below max int value to be RBF
-    };
+      sequence: 0xfffffffd // Needs to be at least 2 below max int value to be RBF
+    }
 
     if (pubKeyType === "taproot") {
-      const xKey = toXOnly(Buffer.from(publicKey, "hex"));
-      const p2tr = createTransaction(xKey, "p2tr", network);
+      const xKey = toXOnly(Buffer.from(publicKey, "hex"))
+      const p2tr = createTransaction(xKey, "p2tr", network)
 
-      input.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"));
+      input.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"))
       input.witnessUtxo = {
         script: p2tr.output!,
         value: utxo.sats
-      };
+      }
     }
 
-    psbt.addInput(input);
+    psbt.addInput(input)
 
-    totalValue += utxo.sats;
-    paymentUtxoCount += 1;
+    totalValue += utxo.sats
+    paymentUtxoCount += 1
 
     const fees = calculateTxFeeWithRate(
       paymentUtxoCount,
       count, // 2-dummy outputs
       feeRate
-    );
+    )
     if (totalValue >= value * count + fees) {
-      break;
+      break
     }
   }
 
@@ -295,12 +280,12 @@ export async function generateDummyUtxos({
     paymentUtxoCount,
     count, // 2-dummy outputs
     feeRate
-  );
+  )
 
-  const changeValue = totalValue - value * count - finalFees;
+  const changeValue = totalValue - value * count - finalFees
   // We must have enough value to create a dummy utxo and pay for tx fees
   if (changeValue < 0) {
-    throw new Error(`You might have pending transactions or not enough fund`);
+    throw new Error(`You might have pending transactions or not enough fund`)
   }
 
   Array(count)
@@ -309,17 +294,17 @@ export async function generateDummyUtxos({
       psbt.addOutput({
         address: address.address!,
         value: val
-      });
-    });
+      })
+    })
 
   if (changeValue > 580) {
     psbt.addOutput({
       address: address.address!,
       value: changeValue
-    });
+    })
   }
 
-  return psbt;
+  return psbt
 }
 
 export async function getSellerInputsOutputs({
@@ -331,118 +316,122 @@ export async function getSellerInputsOutputs({
   network = "testnet",
   side = "seller"
 }: GenerateSellerInstantBuyPsbtOptions) {
-  const format = addressNameToType[pubKeyType];
-  const address = getAddressesFromPublicKey(publicKey, network, format)[0];
+  const format = addressNameToType[pubKeyType]
+  const address = getAddressesFromPublicKey(publicKey, network, format)[0]
 
-  const inputs = [];
-  const outputs = [];
+  const inputs = []
+  const outputs = []
 
-  const { totalUTXOs, unspendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ address: address.address!, network, type: "all" })
+  const { totalUTXOs, unspendableUTXOs } = await OrditApi.fetchUnspentUTXOs({
+    address: address.address!,
+    network,
+    type: "all"
+  })
   if (!totalUTXOs) {
-    throw new Error("No UTXOs found.");
+    throw new Error("No UTXOs found.")
   }
 
-  let found = false;
+  let found = false
 
   for (let i = 0; i < unspendableUTXOs.length; i++) {
-    const unspendableUTXO = unspendableUTXOs[i];
+    const unspendableUTXO = unspendableUTXOs[i]
     if (unspendableUTXO.inscriptions!.find((v: any) => v.outpoint == inscriptionOutPoint)) {
       if (unspendableUTXO.inscriptions!.length > 1) {
-        throw new Error("Multiple inscriptions! Please split them first.");
+        throw new Error("Multiple inscriptions! Please split them first.")
       }
       const { rawTx } = await OrditApi.fetchTx({ txId: unspendableUTXO.txid, network, hex: true })
       if (!rawTx) {
-        throw new Error("Failed to get raw transaction for id: " + unspendableUTXO.txid);
+        throw new Error("Failed to get raw transaction for id: " + unspendableUTXO.txid)
       }
 
       if (format !== "p2tr") {
         for (const output in rawTx.outs) {
           try {
-            rawTx.setWitness(parseInt(output), []);
+            rawTx.setWitness(parseInt(output), [])
           } catch {}
         }
       }
 
-      const options: any = {};
+      const options: any = {}
 
       const data: any = {
         hash: unspendableUTXO.txid,
         index: unspendableUTXO.n,
         nonWitnessUtxo: rawTx.toBuffer(),
         sequence: 0xfffffffd // Needs to be at least 2 below max int value to be RBF
-      };
-      const postage = unspendableUTXO.sats;
+      }
+      const postage = unspendableUTXO.sats
 
       if (side === "seller") {
-        options.sighashType = bitcoin.Transaction.SIGHASH_SINGLE | bitcoin.Transaction.SIGHASH_ANYONECANPAY;
+        options.sighashType = bitcoin.Transaction.SIGHASH_SINGLE | bitcoin.Transaction.SIGHASH_ANYONECANPAY
       }
 
       if (format === "p2tr") {
-        const xKey = toXOnly(Buffer.from(publicKey, "hex"));
-        const p2tr = createTransaction(xKey, "p2tr", network);
+        const xKey = toXOnly(Buffer.from(publicKey, "hex"))
+        const p2tr = createTransaction(xKey, "p2tr", network)
 
-        data.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"));
+        data.tapInternalKey = toXOnly(Buffer.from(publicKey, "hex"))
         data.witnessUtxo = {
           script: p2tr.output!,
           value: postage
-        };
+        }
       }
 
       inputs.push({
         ...data,
         ...options
-      });
-      outputs.push({ address: receiveAddress, value: price + postage });
+      })
+      outputs.push({ address: receiveAddress, value: price + postage })
 
-      found = true;
-      break;
+      found = true
+      break
     }
   }
 
   if (!found) {
-    throw new Error("inscription not found.");
+    throw new Error("inscription not found.")
   }
 
-  return { inputs, outputs };
+  return { inputs, outputs }
 }
 
 export interface UnspentOutput {
-  txId: string;
-  outputIndex: number;
-  satoshis: number;
-  scriptPk: string;
-  addressType: AddressTypes;
-  address: string;
+  txId: string
+  outputIndex: number
+  satoshis: number
+  scriptPk: string
+  addressType: AddressTypes
+  address: string
   ords: {
-    id: string;
-    offset: number;
-  }[];
+    id: string
+    offset: number
+  }[]
 }
 
 export interface GenerateSellerInstantBuyPsbtOptions {
-  inscriptionOutPoint: string;
-  price: number;
-  receiveAddress: string;
-  publicKey: string;
-  pubKeyType?: AddressFormats;
-  network?: Network;
-  side?: "seller" | "buyer";
+  inscriptionOutPoint: string
+  price: number
+  receiveAddress: string
+  publicKey: string
+  pubKeyType?: AddressFormats
+  network?: Network
+  side?: "seller" | "buyer"
 }
 
 export interface GenerateBuyerInstantBuyPsbtOptions {
-  publicKey: string;
-  pubKeyType?: AddressFormats;
-  network?: Network;
-  feeRate?: number;
-  inscriptionOutPoint: string;
-  sellerPsbt: string;
+  publicKey: string
+  pubKeyType?: AddressFormats
+  network?: Network
+  feeRate?: number
+  inscriptionOutPoint: string
+  sellerPsbt: string
 }
 
 export interface GenerateDummyUtxos {
-  value: number;
-  count: number;
-  publicKey: string;
-  pubKeyType?: AddressFormats;
-  network?: Network;
-  feeRate?: number;
+  value: number
+  count: number
+  publicKey: string
+  pubKeyType?: AddressFormats
+  network?: Network
+  feeRate?: number
 }

--- a/packages/sdk/src/inscription/psbt.ts
+++ b/packages/sdk/src/inscription/psbt.ts
@@ -1,10 +1,11 @@
-import { Psbt } from "bitcoinjs-lib";
+import { Psbt } from "bitcoinjs-lib"
 
-import { getAddresses } from "../addresses";
-import { OrditApi } from "../api";
-import { createTransaction, getNetwork } from "../utils";
-import { GetWalletOptions } from "../wallet";
-import { buildWitnessScript } from "./witness";
+import { getAddresses } from "../addresses"
+import { OrditApi } from "../api"
+import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
+import { createTransaction, getNetwork } from "../utils"
+import { GetWalletOptions } from "../wallet"
+import { buildWitnessScript } from "./witness"
 
 export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
   const networkObj = getNetwork(options.network);
@@ -75,7 +76,7 @@ export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
     value: options.postage
   });
 
-  if (change > 600) {
+  if (change > MINIMUM_AMOUNT_IN_SATS) {
     let changeAddress = inscribePayTx.address;
     if (options.changeAddress) {
       changeAddress = options.changeAddress;

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -14,6 +14,7 @@ import {
   OrditApi
 } from ".."
 import { Network } from "../config/types"
+import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
 
 bitcoin.initEccLib(ecc)
 
@@ -125,7 +126,7 @@ export class OrdTransaction {
       })
     }
 
-    if (change > 600) {
+    if (change > MINIMUM_AMOUNT_IN_SATS) {
       let changeAddress = this.#inscribePayTx.address
       if (this.changeAddress) {
         changeAddress = this.changeAddress

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -1,6 +1,6 @@
-import * as ecc from "@bitcoinerlab/secp256k1";
-import * as bitcoin from "bitcoinjs-lib";
-import { Tapleaf } from "bitcoinjs-lib/src/types";
+import * as ecc from "@bitcoinerlab/secp256k1"
+import * as bitcoin from "bitcoinjs-lib"
+import { Tapleaf } from "bitcoinjs-lib/src/types"
 
 import {
   buildWitnessScript,
@@ -11,30 +11,30 @@ import {
   GetWalletOptions,
   OnOffUnion,
   OrditApi
-} from "..";
-import { Network } from "../config/types";
+} from ".."
+import { Network } from "../config/types"
 
-bitcoin.initEccLib(ecc);
+bitcoin.initEccLib(ecc)
 
 export class OrdTransaction {
-  publicKey: string;
-  feeRate: number;
-  postage: number;
-  mediaType: string;
-  mediaContent: string;
-  destinationAddress: string;
-  changeAddress: string;
-  meta: object | unknown;
-  network: Network;
-  psbt: bitcoin.Psbt | null = null;
-  ready = false;
-  #xKey: string;
-  #feeForWitnessData: number | null = null;
-  #commitAddress: string | null = null;
-  #inscribePayTx: ReturnType<typeof createTransaction> | null = null;
-  #suitableUnspent: any = null;
-  #recovery = false;
-  #outs: Outputs = [];
+  publicKey: string
+  feeRate: number
+  postage: number
+  mediaType: string
+  mediaContent: string
+  destinationAddress: string
+  changeAddress: string
+  meta: object | unknown
+  network: Network
+  psbt: bitcoin.Psbt | null = null
+  ready = false
+  #xKey: string
+  #feeForWitnessData: number | null = null
+  #commitAddress: string | null = null
+  #inscribePayTx: ReturnType<typeof createTransaction> | null = null
+  #suitableUnspent: any = null
+  #recovery = false
+  #outs: Outputs = []
   #safeMode: OnOffUnion
 
   constructor({
@@ -47,53 +47,53 @@ export class OrdTransaction {
     ...otherOptions
   }: OrdTransactionOptions) {
     if (!publicKey || !otherOptions.changeAddress || !otherOptions.destination || !otherOptions.mediaContent) {
-      throw new Error("Invalid options provided.");
+      throw new Error("Invalid options provided.")
     }
 
-    this.publicKey = publicKey;
-    this.feeRate = feeRate;
-    this.mediaType = mediaType;
-    this.network = network;
-    this.changeAddress = otherOptions.changeAddress;
-    this.destinationAddress = otherOptions.destination;
-    this.mediaContent = otherOptions.mediaContent;
-    this.meta = otherOptions.meta;
-    this.postage = postage;
-    this.#outs = outs;
-    this.#safeMode = !otherOptions.safeMode ? "on": otherOptions.safeMode
+    this.publicKey = publicKey
+    this.feeRate = feeRate
+    this.mediaType = mediaType
+    this.network = network
+    this.changeAddress = otherOptions.changeAddress
+    this.destinationAddress = otherOptions.destination
+    this.mediaContent = otherOptions.mediaContent
+    this.meta = otherOptions.meta
+    this.postage = postage
+    this.#outs = outs
+    this.#safeMode = !otherOptions.safeMode ? "on" : otherOptions.safeMode
 
-    const xKey = getAddressesFromPublicKey(publicKey, network, "p2tr")[0].xkey;
+    const xKey = getAddressesFromPublicKey(publicKey, network, "p2tr")[0].xkey
 
     if (!xKey) {
-      throw new Error("Failed to derive xKey from the provided public key.");
+      throw new Error("Failed to derive xKey from the provided public key.")
     }
 
-    this.#xKey = xKey;
+    this.#xKey = xKey
   }
 
   get outs() {
-    return this.#outs;
+    return this.#outs
   }
 
   build() {
     if (!this.#suitableUnspent || !this.#inscribePayTx) {
-      throw new Error("Failed to build PSBT. Transaction not ready.");
+      throw new Error("Failed to build PSBT. Transaction not ready.")
     }
 
-    let fees = this.#feeForWitnessData!;
+    let fees = this.#feeForWitnessData!
 
     if (this.#recovery) {
-      fees = calculateTxFeeWithRate(1, 0, this.feeRate, 1);
+      fees = calculateTxFeeWithRate(1, 0, this.feeRate, 1)
     }
 
     const customOutsAmount = this.#outs.reduce((acc, cur) => {
-      return acc + cur.value;
-    }, 0);
-    const change = this.#suitableUnspent.sats - fees - customOutsAmount - this.postage;
+      return acc + cur.value
+    }, 0)
+    const change = this.#suitableUnspent.sats - fees - customOutsAmount - this.postage
 
-    const networkObj = getNetwork(this.network);
+    const networkObj = getNetwork(this.network)
 
-    const psbt = new bitcoin.Psbt({ network: networkObj });
+    const psbt = new bitcoin.Psbt({ network: networkObj })
 
     try {
       psbt.addInput({
@@ -112,59 +112,59 @@ export class OrdTransaction {
             controlBlock: this.#inscribePayTx.witness![this.#inscribePayTx.witness!.length - 1]
           }
         ]
-      });
+      })
 
       if (!this.#recovery) {
         psbt.addOutput({
           address: this.destinationAddress,
           value: this.postage
-        });
+        })
 
         this.#outs.forEach((out) => {
-          psbt.addOutput(out);
-        });
+          psbt.addOutput(out)
+        })
       }
 
       if (change > 600) {
-        let changeAddress = this.#inscribePayTx.address;
+        let changeAddress = this.#inscribePayTx.address
         if (this.changeAddress) {
-          changeAddress = this.changeAddress;
+          changeAddress = this.changeAddress
         }
 
         psbt.addOutput({
           address: changeAddress!,
           value: change
-        });
+        })
       }
 
-      this.psbt = psbt;
+      this.psbt = psbt
     } catch (error) {
-      throw new Error(error.message);
+      throw new Error(error.message)
     }
   }
 
   toPsbt() {
     if (!this.psbt) {
-      throw new Error("No PSBT found. Please build first.");
+      throw new Error("No PSBT found. Please build first.")
     }
 
-    return this.psbt;
+    return this.psbt
   }
 
   toHex() {
     if (!this.psbt) {
-      throw new Error("No PSBT found. Please build first.");
+      throw new Error("No PSBT found. Please build first.")
     }
 
-    return this.psbt.toHex();
+    return this.psbt.toHex()
   }
 
   toBase64() {
     if (!this.psbt) {
-      throw new Error("No PSBT found. Please build first.");
+      throw new Error("No PSBT found. Please build first.")
     }
 
-    return this.psbt.toBase64();
+    return this.psbt.toBase64()
   }
 
   generateCommit() {
@@ -173,17 +173,17 @@ export class OrdTransaction {
       mediaType: this.mediaType,
       meta: this.meta,
       xkey: this.#xKey
-    });
+    })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
       meta: this.meta,
       xkey: this.#xKey,
       recover: true
-    });
+    })
 
     if (!witnessScript || !recoverScript) {
-      throw new Error("Failed to build createRevealPsbt");
+      throw new Error("Failed to build createRevealPsbt")
     }
 
     const scriptTree: [Tapleaf, Tapleaf] = [
@@ -193,38 +193,38 @@ export class OrdTransaction {
       {
         output: recoverScript
       }
-    ];
+    ]
 
     const redeemScript = {
       output: witnessScript,
       redeemVersion: 192
-    };
+    }
 
     const inscribePayTx = createTransaction(Buffer.from(this.#xKey, "hex"), "p2tr", this.network, {
       scriptTree: scriptTree,
       redeem: redeemScript
-    });
+    })
 
-    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * this.feeRate));
-    const scriptLength = witnessScript.toString("hex").length;
-    const scriptFees = Math.ceil((scriptLength / 10) * this.feeRate + fees);
+    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * this.feeRate))
+    const scriptLength = witnessScript.toString("hex").length
+    const scriptFees = Math.ceil((scriptLength / 10) * this.feeRate + fees)
     const customOutsAmount = this.#outs.reduce((acc, cur) => {
-      return acc + cur.value;
-    }, 0);
+      return acc + cur.value
+    }, 0)
 
-    this.#feeForWitnessData = scriptFees;
-    this.#commitAddress = inscribePayTx.address!;
-    this.#inscribePayTx = inscribePayTx;
+    this.#feeForWitnessData = scriptFees
+    this.#commitAddress = inscribePayTx.address!
+    this.#inscribePayTx = inscribePayTx
 
     return {
       address: inscribePayTx.address!,
       revealFee: this.postage + scriptFees + customOutsAmount
-    };
+    }
   }
 
   recover() {
     if (!this.#inscribePayTx || !this.ready) {
-      throw new Error("Transaction not ready.");
+      throw new Error("Transaction not ready.")
     }
 
     const witnessScript = buildWitnessScript({
@@ -232,17 +232,17 @@ export class OrdTransaction {
       mediaType: this.mediaType,
       meta: this.meta,
       xkey: this.#xKey
-    });
+    })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
       meta: this.meta,
       xkey: this.#xKey,
       recover: true
-    });
+    })
 
     if (!witnessScript || !recoverScript) {
-      throw new Error("Failed to build createRevealPsbt");
+      throw new Error("Failed to build createRevealPsbt")
     }
 
     const scriptTree: [Tapleaf, Tapleaf] = [
@@ -252,79 +252,83 @@ export class OrdTransaction {
       {
         output: recoverScript
       }
-    ];
+    ]
 
     const redeemScript = {
       output: recoverScript,
       redeemVersion: 192
-    };
+    }
 
     const inscribePayTx = createTransaction(Buffer.from(this.#xKey, "hex"), "p2tr", this.network, {
       scriptTree: scriptTree,
       redeem: redeemScript
-    });
+    })
 
-    this.#inscribePayTx = inscribePayTx;
-    this.#recovery = true;
+    this.#inscribePayTx = inscribePayTx
+    this.#recovery = true
   }
 
   async isReady() {
     if (!this.#commitAddress || !this.#feeForWitnessData) {
-      throw new Error("No commit address found. Please generate a commit address.");
+      throw new Error("No commit address found. Please generate a commit address.")
     }
 
     if (!this.ready) {
       try {
-        await this.fetchAndSelectSuitableUnspent();
+        await this.fetchAndSelectSuitableUnspent()
       } catch (error) {
-        return false;
+        return false
       }
     }
 
-    return this.ready;
+    return this.ready
   }
 
   async fetchAndSelectSuitableUnspent() {
     if (!this.#commitAddress || !this.#feeForWitnessData) {
-      throw new Error("No commit address found. Please generate a commit address.");
+      throw new Error("No commit address found. Please generate a commit address.")
     }
 
-    const { spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ 
-      address: this.#commitAddress, network: this.network,
+    const { spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({
+      address: this.#commitAddress,
+      network: this.network
     })
 
     const customOutsAmount = this.#outs.reduce((acc, cur) => {
-      return acc + cur.value;
-    }, 0);
+      return acc + cur.value
+    }, 0)
 
     const suitableUTXO = spendableUTXOs.find((utxo) => {
-      if (utxo.sats >= this.postage + this.#feeForWitnessData! + customOutsAmount && (this.#safeMode === 'off' || (this.#safeMode === 'on' && utxo.safeToSpend === true))) {
-        return true;
+      if (
+        utxo.sats >= this.postage + this.#feeForWitnessData! + customOutsAmount &&
+        (this.#safeMode === "off" || (this.#safeMode === "on" && utxo.safeToSpend === true))
+      ) {
+        return true
       }
-    }, this);
+    }, this)
 
     if (!suitableUTXO) {
-      throw new Error("No suitable unspent found for reveal.");
+      throw new Error("No suitable unspent found for reveal.")
     }
 
-    this.#suitableUnspent = suitableUTXO;
-    this.ready = true;
+    this.#suitableUnspent = suitableUTXO
+    this.ready = true
 
-    return suitableUTXO;
+    return suitableUTXO
   }
 }
 
-export type OrdTransactionOptions = Pick<GetWalletOptions, 'safeMode'> & {
-  feeRate?: number;
-  postage?: number;
-  mediaType?: string;
-  mediaContent: string;
-  destination: string;
-  changeAddress: string;
-  meta?: object | unknown;
-  network?: Network;
-  publicKey: string;
-  outs?: Outputs;
-};
+export type OrdTransactionOptions = Pick<GetWalletOptions, "safeMode"> & {
+  feeRate?: number
+  postage?: number
+  mediaType?: string
+  mediaContent: string
+  destination: string
+  changeAddress: string
+  meta?: object | unknown
+  network?: Network
+  publicKey: string
+  outs?: Outputs
+}
 
-type Outputs = Array<{ address: string; value: number }>;
+type Outputs = Array<{ address: string; value: number }>

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -202,6 +202,7 @@ export class OrdTransaction {
       redeem: redeemScript
     })
 
+    // inscription tx always have 1 input and 1 output
     const fees = calculateTxFee({
       totalInputs: 1,
       totalOutputs: 1,

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -208,7 +208,7 @@ export class OrdTransaction {
       totalOutputs: 1,
       satsPerByte: this.feeRate,
       type: "taproot",
-      additional: { witnessScript }
+      additional: { witnessScripts: [witnessScript] }
     })
 
     const customOutsAmount = this.#outs.reduce((acc, cur) => {

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -5,7 +5,6 @@ import { Tapleaf } from "bitcoinjs-lib/src/types"
 import {
   buildWitnessScript,
   calculateTxFee,
-  calculateTxFeeWithRate,
   createTransaction,
   getAddressesFromPublicKey,
   getNetwork,
@@ -85,7 +84,12 @@ export class OrdTransaction {
     let fees = this.#feeForWitnessData!
 
     if (this.#recovery) {
-      fees = calculateTxFeeWithRate(1, 0, this.feeRate, 1)
+      fees = calculateTxFee({
+        totalInputs: 1,
+        totalOutputs: 1, // change output
+        satsPerByte: this.feeRate,
+        type: "taproot" // hardcoding because recovery is only supported by Taproot txs
+      })
     }
 
     const customOutsAmount = this.#outs.reduce((acc, cur) => {
@@ -208,7 +212,7 @@ export class OrdTransaction {
       totalInputs: 1,
       totalOutputs: 1,
       satsPerByte: this.feeRate,
-      type: "taproot",
+      type: "taproot", // hardcoding because this process is only supported by Taproot txs
       additional: { witnessScripts: [witnessScript] }
     })
 

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -201,7 +201,7 @@ export class OrdTransaction {
       redeem: redeemScript
     })
 
-    const fees = JSON.parse(JSON.stringify((80 + 1 * 180) * this.feeRate))
+    const fees = (80 + 1 * 180) * this.feeRate
     const scriptLength = witnessScript.toString("hex").length
     const scriptFees = Math.ceil((scriptLength / 10) * this.feeRate + fees)
     const customOutsAmount = this.#outs.reduce((acc, cur) => {

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -1,6 +1,6 @@
 import * as ecc from "@bitcoinerlab/secp256k1"
 import { BIP32Factory } from "bip32"
-import { Psbt } from "bitcoinjs-lib"
+import { Psbt, Transaction } from "bitcoinjs-lib"
 
 import { getAddressType } from "../addresses"
 import { addressTypeToName } from "../addresses/formats"
@@ -47,7 +47,7 @@ export async function createPsbt({
   for (const utxo of spendableUTXOs) {
     if (utxo.scriptPubKey.address !== address) continue
 
-    const payload = await processInput(utxo, pubKey, network, enableRBF)
+    const payload = await processInput({ utxo, pubKey, network, enableRBF })
     payload.witnessUtxo?.script && witnessScripts.push(payload.witnessUtxo?.script)
     psbt.addInput(payload)
   }
@@ -87,26 +87,41 @@ export async function createPsbt({
   }
 }
 
-export async function processInput(utxo: UTXO, pubKey: string, network: Network, enableRBF = true): Promise<InputType> {
+export async function processInput({
+  utxo,
+  pubKey,
+  network,
+  enableRBF = true,
+  ...options
+}: Omit<ProcessInputOptions, "rawTx">): Promise<InputType> {
+  const { rawTx } = await OrditApi.fetchTx({ txId: utxo.txid, network, hex: true })
+
   switch (utxo.scriptPubKey.type) {
     case "witness_v1_taproot":
-      return generateTaprootInput(utxo, pubKey, network, enableRBF)
+      return generateTaprootInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })
 
     case "witness_v0_scripthash":
-      return generateSegwitInput(utxo, pubKey, network, enableRBF)
+      return generateSegwitInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })
 
     case "scripthash":
-      return generateNestedSegwitInput(utxo, pubKey, network, enableRBF)
+      return generateNestedSegwitInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })
 
     case "pubkeyhash":
-      return generateLegacyInput(utxo, network, enableRBF)
+      return generateLegacyInput({ utxo, rawTx, enableRBF, ...options })
 
     default:
       throw new Error("invalid script pub type")
   }
 }
 
-function generateTaprootInput(utxo: UTXO, pubKey: string, network: Network, enableRPF = true): TaprootInputType {
+function generateTaprootInput({
+  utxo,
+  pubKey,
+  network,
+  enableRBF,
+  sighashType,
+  rawTx
+}: ProcessInputOptions): TaprootInputType {
   const chainCode = Buffer.alloc(32)
   chainCode.fill(1)
 
@@ -121,16 +136,18 @@ function generateTaprootInput(utxo: UTXO, pubKey: string, network: Network, enab
   return {
     hash: utxo.txid,
     index: utxo.n,
-    sequence: enableRPF ? 0xfffffffd : undefined,
+    sequence: enableRBF ? 0xfffffffd : undefined,
     tapInternalKey: childNodeXOnlyPubkey,
+    nonWitnessUtxo: rawTx?.toBuffer() ?? undefined,
     witnessUtxo: {
       script: p2tr.output,
       value: utxo.sats
-    }
+    },
+    ...(sighashType ? { sighashType } : undefined)
   }
 }
 
-function generateSegwitInput(utxo: UTXO, pubKey: string, network: Network, enableRPF = true): SegwitInputType {
+function generateSegwitInput({ utxo, pubKey, network, enableRBF, sighashType }: ProcessInputOptions): SegwitInputType {
   const p2wpkh = createTransaction(Buffer.from(pubKey, "hex"), "p2wpkh", network)
   if (!p2wpkh || !p2wpkh.output) {
     throw new Error("Unable to process Segwit input")
@@ -139,20 +156,22 @@ function generateSegwitInput(utxo: UTXO, pubKey: string, network: Network, enabl
   return {
     hash: utxo.txid,
     index: utxo.n,
-    sequence: enableRPF ? 0xfffffffd : undefined,
+    sequence: enableRBF ? 0xfffffffd : undefined,
     witnessUtxo: {
       script: p2wpkh.output,
       value: utxo.sats
-    }
+    },
+    ...(sighashType ? { sighashType } : undefined)
   }
 }
 
-function generateNestedSegwitInput(
-  utxo: UTXO,
-  pubKey: string,
-  network: Network,
-  enableRPF = true
-): NestedSegwitInputType {
+function generateNestedSegwitInput({
+  utxo,
+  pubKey,
+  network,
+  enableRBF,
+  sighashType
+}: ProcessInputOptions): NestedSegwitInputType {
   const p2sh = createTransaction(Buffer.from(pubKey, "hex"), "p2sh", network)
   if (!p2sh || !p2sh.output || !p2sh.redeem) {
     throw new Error("Unable to process Segwit input")
@@ -161,26 +180,32 @@ function generateNestedSegwitInput(
   return {
     hash: utxo.txid,
     index: utxo.n,
-    sequence: enableRPF ? 0xfffffffd : undefined,
+    sequence: enableRBF ? 0xfffffffd : undefined,
     redeemScript: p2sh.redeem.output,
     witnessUtxo: {
       script: p2sh.output,
       value: utxo.sats
-    }
+    },
+    ...(sighashType ? { sighashType } : undefined)
   }
 }
 
-async function generateLegacyInput(utxo: UTXO, network: Network, enableRPF = true): Promise<LegacyInputType> {
-  const { tx } = await OrditApi.fetchTx({ txId: utxo.txid, hex: true, ordinals: false, network })
-  if (!tx) {
+async function generateLegacyInput({
+  utxo,
+  enableRBF,
+  sighashType,
+  rawTx
+}: Omit<ProcessInputOptions, "pubKey" | "network">): Promise<LegacyInputType> {
+  if (!rawTx) {
     throw new Error("Unable to process Legacy input")
   }
 
   return {
     hash: utxo.txid,
     index: utxo.n,
-    sequence: enableRPF ? 0xfffffffd : undefined,
-    nonWitnessUtxo: Buffer.from(tx.hex!, "hex")
+    sequence: enableRBF ? 0xfffffffd : undefined,
+    nonWitnessUtxo: rawTx.toBuffer(),
+    ...(sighashType ? { sighashType } : undefined)
   }
 }
 
@@ -189,50 +214,63 @@ interface TaprootInputType {
   hash: string
   index: number
   sequence?: number
+  sighashType?: number
   tapInternalKey?: Buffer
   witnessUtxo?: {
     script: Buffer
     value: number
   }
-  nonWitnessUtxo?: never
+  nonWitnessUtxo?: Buffer
 }
 
 interface SegwitInputType {
   hash: string
   index: number
   sequence?: number
+  sighashType?: number
   witnessUtxo?: {
     script: Buffer
     value: number
   }
-  nonWitnessUtxo?: never
+  nonWitnessUtxo?: Buffer
 }
 
 interface NestedSegwitInputType {
   hash: string
   index: number
   sequence?: number
+  sighashType?: number
   redeemScript?: Buffer | undefined
   witnessUtxo?: {
     script: Buffer
     value: number
   }
-  nonWitnessUtxo?: never
+  nonWitnessUtxo?: Buffer
 }
 
 interface LegacyInputType {
   hash: string
   index: number
   sequence?: number
+  sighashType?: number
   nonWitnessUtxo?: Buffer
   witnessUtxo?: never
 }
 
-type InputType = TaprootInputType | SegwitInputType | NestedSegwitInputType | LegacyInputType
+export type InputType = TaprootInputType | SegwitInputType | NestedSegwitInputType | LegacyInputType
 
 export type CreatePsbtOptions = GetWalletOptions & {
   satsPerByte?: number
   ins: any[]
   outs: any[]
   enableRBF: boolean
+}
+
+interface ProcessInputOptions {
+  utxo: UTXO
+  pubKey: string
+  network: Network
+  enableRBF?: boolean
+  sighashType?: number
+  rawTx?: Transaction
 }

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -65,7 +65,7 @@ export async function createPsbt({
         const scriptPubKeyType = spendable.scriptPubKey.type as string
         let addedInputSuccessfully = false
 
-        fees = JSON.parse(JSON.stringify((80 + (inputs_used + 1) * 180) * sats_per_byte))
+        fees = (80 + (inputs_used + 1) * 180) * sats_per_byte
 
         if (input.address === "any") {
           ins[idx].address = scriptPubKeyAddress

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -2,6 +2,7 @@ import * as ecc from "@bitcoinerlab/secp256k1"
 import BIP32Factory, { BIP32API } from "bip32"
 import { Network, Psbt } from "bitcoinjs-lib"
 
+import { OrditApi } from "../api"
 import { createTransaction, getNetwork } from "../utils"
 import { GetWalletOptions, getWalletWithBalances } from "../wallet"
 
@@ -57,13 +58,12 @@ export async function createPsbt({
     }
   })
 
-  ins.forEach((input, idx) => {
+  for (const [idx, input] of ins.entries()) {
     if (input.address) {
-      walletWithBalances.spendables.forEach((spendable: any) => {
+      for (const spendable of walletWithBalances.spendables) {
         const sats = spendable.sats
         const scriptPubKeyAddress = spendable.scriptPubKey.address
         const scriptPubKeyType = spendable.scriptPubKey.type as string
-        let addedInputSuccessfully = false
 
         fees = (80 + (inputs_used + 1) * 180) * sats_per_byte
 
@@ -72,7 +72,13 @@ export async function createPsbt({
         }
 
         if (input.address === scriptPubKeyAddress) {
-          addedInputSuccessfully = addInputToPsbtByType(spendable, scriptPubKeyType, psbt, bip32, netWorkObj)
+          const addedInputSuccessfully = await addInputToPsbtByType(
+            spendable,
+            scriptPubKeyType,
+            psbt,
+            bip32,
+            netWorkObj
+          )
 
           if (addedInputSuccessfully) {
             unspents_to_use.push(spendable)
@@ -86,9 +92,9 @@ export async function createPsbt({
             unsupported_inputs.push(spendable)
           }
         }
-      })
+      }
     }
-  })
+  }
 
   if (!unspents_to_use.length) {
     throw new Error(
@@ -118,7 +124,7 @@ export async function createPsbt({
   }
 }
 
-function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: BIP32API, network: Network) {
+async function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: BIP32API, network: Network) {
   if (type === "witness_v1_taproot") {
     const chainCode = Buffer.alloc(32)
     chainCode.fill(1)
@@ -186,11 +192,12 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
       //fail silently
     }
   } else if (type === "pubkeyhash") {
+    const { tx } = await OrditApi.fetchTx({ txId: spendable.txid, hex: true, ordinals: false })
     try {
       psbt.addInput({
         hash: spendable.txid,
-        index: parseInt(spendable.n),
-        nonWitnessUtxo: Buffer.from(spendable.txhex, "hex")
+        index: spendable.n,
+        nonWitnessUtxo: Buffer.from(tx.hex!, "hex")
       })
 
       return true

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -6,6 +6,7 @@ import { getAddressType } from "../addresses"
 import { addressTypeToName } from "../addresses/formats"
 import { OrditApi } from "../api"
 import { Network } from "../config/types"
+import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
 import { calculateTxFee, createTransaction, getNetwork, toXOnly } from "../utils"
 import { GetWalletOptions } from "../wallet"
 import { UTXO } from "./types"
@@ -65,7 +66,7 @@ export async function createPsbt({
     throw new Error(`Insufficient balance. Available: ${inputSats}. Attemping to spend: ${outputSats}. Fees: ${fees}`)
   }
 
-  const isChangeOwed = remainingBalance > 600
+  const isChangeOwed = remainingBalance > MINIMUM_AMOUNT_IN_SATS
   if (isChangeOwed) {
     outs.push({
       address,

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -1,9 +1,9 @@
-import * as ecc from "@bitcoinerlab/secp256k1";
-import BIP32Factory, { BIP32API } from "bip32";
-import { Network, Psbt } from "bitcoinjs-lib";
+import * as ecc from "@bitcoinerlab/secp256k1"
+import BIP32Factory, { BIP32API } from "bip32"
+import { Network, Psbt } from "bitcoinjs-lib"
 
-import { createTransaction, getNetwork } from "../utils";
-import { GetWalletOptions, getWalletWithBalances } from "../wallet";
+import { createTransaction, getNetwork } from "../utils"
+import { GetWalletOptions, getWalletWithBalances } from "../wallet"
 
 export async function createPsbt({
   network,
@@ -14,124 +14,124 @@ export async function createPsbt({
   safeMode = "on",
   satsPerByte
 }: CreatePsbtOptions) {
-  const netWorkObj = getNetwork(network);
-  const bip32 = BIP32Factory(ecc);
+  const netWorkObj = getNetwork(network)
+  const bip32 = BIP32Factory(ecc)
 
   const walletWithBalances = await getWalletWithBalances({
     pubKey,
     format,
     network,
     safeMode
-  });
+  })
 
   if (walletWithBalances?.spendables === undefined) {
     throw new Error(
       "The derived wallet doesn't contain any spendable sats. It may be empty or contain sats that are either linked to inscriptions or tied to ordinals."
-    );
+    )
   }
 
-  let fees = 0;
-  let change = 0;
-  const dust = 600;
-  let inputs_used = 0;
-  const sats_per_byte = satsPerByte ?? 10;
-  let total_cardinals_to_send = 0;
-  let total_cardinals_available = 0;
-  const unsupported_inputs = [];
-  const unspents_to_use = [];
-  const xverse_inputs = [];
+  let fees = 0
+  let change = 0
+  const dust = 600
+  let inputs_used = 0
+  const sats_per_byte = satsPerByte ?? 10
+  let total_cardinals_to_send = 0
+  let total_cardinals_available = 0
+  const unsupported_inputs = []
+  const unspents_to_use = []
+  const xverse_inputs = []
 
-  const psbt = new Psbt({ network: netWorkObj });
+  const psbt = new Psbt({ network: netWorkObj })
 
   outs.forEach((output) => {
     try {
-      if (!output.cardinals) throw new Error("No cardinals in output.");
+      if (!output.cardinals) throw new Error("No cardinals in output.")
 
-      total_cardinals_to_send = +parseInt(output.cardinals);
+      total_cardinals_to_send = +parseInt(output.cardinals)
       psbt.addOutput({
         address: output.address,
         value: parseInt(output.cardinals)
-      });
+      })
     } catch (error) {
       //handle error
     }
-  });
+  })
 
   ins.forEach((input, idx) => {
     if (input.address) {
       walletWithBalances.spendables.forEach((spendable: any) => {
-        const sats = spendable.sats;
-        const scriptPubKeyAddress = spendable.scriptPubKey.address;
-        const scriptPubKeyType = spendable.scriptPubKey.type as string;
-        let addedInputSuccessfully = false;
+        const sats = spendable.sats
+        const scriptPubKeyAddress = spendable.scriptPubKey.address
+        const scriptPubKeyType = spendable.scriptPubKey.type as string
+        let addedInputSuccessfully = false
 
-        fees = JSON.parse(JSON.stringify((80 + (inputs_used + 1) * 180) * sats_per_byte));
+        fees = JSON.parse(JSON.stringify((80 + (inputs_used + 1) * 180) * sats_per_byte))
 
         if (input.address === "any") {
-          ins[idx].address = scriptPubKeyAddress;
+          ins[idx].address = scriptPubKeyAddress
         }
 
         if (input.address === scriptPubKeyAddress) {
-          addedInputSuccessfully = addInputToPsbtByType(spendable, scriptPubKeyType, psbt, bip32, netWorkObj);
+          addedInputSuccessfully = addInputToPsbtByType(spendable, scriptPubKeyType, psbt, bip32, netWorkObj)
 
           if (addedInputSuccessfully) {
-            unspents_to_use.push(spendable);
-            total_cardinals_available += sats;
+            unspents_to_use.push(spendable)
+            total_cardinals_available += sats
             xverse_inputs.push({
               address: scriptPubKeyAddress,
               signingIndexes: [inputs_used]
-            });
-            inputs_used++;
+            })
+            inputs_used++
           } else {
-            unsupported_inputs.push(spendable);
+            unsupported_inputs.push(spendable)
           }
         }
-      });
+      })
     }
-  });
+  })
 
   if (!unspents_to_use.length) {
     throw new Error(
       `Not enough input value to cover outputs and fees. Total cardinals available: '${total_cardinals_available}'. Cardinals to send: '${total_cardinals_to_send}'. Estimated fees: '${fees}'.`
-    );
+    )
   }
 
-  change = total_cardinals_available - (total_cardinals_to_send + fees);
+  change = total_cardinals_available - (total_cardinals_to_send + fees)
 
   if (change < 0) {
-    throw new Error(`Insufficient balance for tx. Deposit ${change * -1} sats or adjust transfer amount to proceed`);
+    throw new Error(`Insufficient balance for tx. Deposit ${change * -1} sats or adjust transfer amount to proceed`)
   }
 
   if (change >= dust) {
     psbt.addOutput({
       address: ins[0].address,
       value: change
-    });
+    })
   }
 
-  const psbtHex = psbt.toHex();
-  const psbtBase64 = psbt.toBase64();
+  const psbtHex = psbt.toHex()
+  const psbtBase64 = psbt.toBase64()
 
   return {
     hex: psbtHex,
     base64: psbtBase64
-  };
+  }
 }
 
 function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: BIP32API, network: Network) {
   if (type === "witness_v1_taproot") {
-    const chainCode = Buffer.alloc(32);
-    chainCode.fill(1);
+    const chainCode = Buffer.alloc(32)
+    chainCode.fill(1)
 
-    let childNodeXOnlyPubkey = Buffer.from(spendable.pub, "hex");
+    let childNodeXOnlyPubkey = Buffer.from(spendable.pub, "hex")
     try {
-      const key = bip32.fromPublicKey(Buffer.from(spendable.pub, "hex"), chainCode, network);
-      childNodeXOnlyPubkey = key.publicKey.subarray(1, 33);
+      const key = bip32.fromPublicKey(Buffer.from(spendable.pub, "hex"), chainCode, network)
+      childNodeXOnlyPubkey = key.publicKey.subarray(1, 33)
     } catch (error) {
       // fail silently
     }
 
-    const p2tr = createTransaction(childNodeXOnlyPubkey, "p2tr", network);
+    const p2tr = createTransaction(childNodeXOnlyPubkey, "p2tr", network)
 
     if (p2tr && p2tr.output) {
       psbt.addInput({
@@ -142,13 +142,13 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
           script: p2tr.output,
           value: parseInt(spendable.sats)
         }
-      });
+      })
 
-      return true;
+      return true
     }
   } else if (type === "witness_v0_keyhash") {
     try {
-      const p2wpkh = createTransaction(Buffer.from(spendable.pub, "hex"), "p2wpkh", network);
+      const p2wpkh = createTransaction(Buffer.from(spendable.pub, "hex"), "p2wpkh", network)
 
       if (p2wpkh && p2wpkh.output) {
         psbt.addInput({
@@ -158,16 +158,16 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
             script: p2wpkh.output,
             value: parseInt(spendable.sats)
           }
-        });
+        })
       }
 
-      return true;
+      return true
     } catch (e) {
       //fail silently
     }
   } else if (type === "scripthash") {
     try {
-      const p2sh = createTransaction(Buffer.from(spendable.pub, "hex"), "p2sh", network);
+      const p2sh = createTransaction(Buffer.from(spendable.pub, "hex"), "p2sh", network)
 
       if (p2sh && p2sh.output && p2sh.redeem) {
         psbt.addInput({
@@ -178,9 +178,9 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
             script: p2sh.output,
             value: parseInt(spendable.sats)
           }
-        });
+        })
 
-        return true;
+        return true
       }
     } catch (error) {
       //fail silently
@@ -191,19 +191,19 @@ function addInputToPsbtByType(spendable: any, type: string, psbt: Psbt, bip32: B
         hash: spendable.txid,
         index: parseInt(spendable.n),
         nonWitnessUtxo: Buffer.from(spendable.txhex, "hex")
-      });
+      })
 
-      return true;
+      return true
     } catch (e) {
       //fail silently
     }
   }
 
-  return false;
+  return false
 }
 
 export type CreatePsbtOptions = GetWalletOptions & {
-  satsPerByte?: number;
-  ins: any[];
-  outs: any[];
-};
+  satsPerByte?: number
+  ins: any[]
+  outs: any[]
+}

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -1,19 +1,19 @@
 declare interface Window {
-  unisat: Unisat;
-  satsConnect: any;
-  ethereum: MetaMask;
+  unisat: Unisat
+  satsConnect: any
+  ethereum: MetaMask
 }
 
 type Unisat = {
-  getNetwork: () => Promise<UnisatNetwork>;
-  switchNetwork: (targetNetwork: UnisatNetwork) => Promise<void>;
-  requestAccounts: () => Promise<string[]>;
-  getPublicKey: () => Promise<string>;
-  signPsbt: (hex: string) => Promise<string>;
-  signMessage: (message: string) => Promise<string>;
-};
+  getNetwork: () => Promise<UnisatNetwork>
+  switchNetwork: (targetNetwork: UnisatNetwork) => Promise<void>
+  requestAccounts: () => Promise<string[]>
+  getPublicKey: () => Promise<string>
+  signPsbt: (hex: string, { autoFinalized }: Record<string, boolean>) => Promise<string>
+  signMessage: (message: string) => Promise<string>
+}
 
 type MetaMask = {
-  isMetaMask: boolean;
-  request: (options: { method: string; params?: any }) => Promise<any>;
-};
+  isMetaMask: boolean
+  request: (options: { method: string; params?: any }) => Promise<any>
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -5,7 +5,7 @@ import ECPairFactory from "ecpair"
 
 import { AddressFormats, AddressTypes } from "../addresses/formats"
 import { Network } from "../config/types"
-import { CalculateTxFeeOptions, CalculateTxWeightOptions } from "./types"
+import { CalculateTxFeeOptions, CalculateTxVirtualSizeOptions } from "./types"
 
 export function getNetwork(value: Network) {
   if (value === "mainnet") {
@@ -112,11 +112,11 @@ export function calculateTxFee({
   type,
   additional = {}
 }: CalculateTxFeeOptions): number {
-  const txWeight = calculateTxWeight({ totalInputs, totalOutputs, type, additional })
+  const txWeight = calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional })
   return txWeight * satsPerByte
 }
 
-export function calculateTxWeight({ totalInputs, totalOutputs, type, additional }: CalculateTxWeightOptions) {
+export function calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional }: CalculateTxVirtualSizeOptions) {
   const baseWeight = getInputOutputBaseWeightByType(type)
 
   const inputVBytes = baseWeight.input * totalInputs
@@ -126,7 +126,6 @@ export function calculateTxWeight({ totalInputs, totalOutputs, type, additional 
     additional && Buffer.isBuffer(additional?.witnessScript) ? additional.witnessScript.byteLength : 0
   const weight = 3 * baseVBytes + (baseVBytes + additionalVBytes)
   const vSize = Math.ceil(weight / 4)
-  console.log("weight >>", inputVBytes, outputVBytes, baseVBytes, additionalVBytes, weight, vSize)
 
   return vSize
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -59,21 +59,6 @@ export function hdNodeToChild(
   return node.derivePath(fullDerivationPath)
 }
 
-export function calculateTxFeeWithRate(
-  inputsLength: number,
-  outputsLength: number,
-  feeRate = 10,
-  hasChangeOutput: 0 | 1 = 1
-): number {
-  const baseTxSize = 10
-  const inSize = 180
-  const outSize = 34
-
-  const txSize = baseTxSize + inputsLength * inSize + outputsLength * outSize + hasChangeOutput * outSize
-  const fee = txSize * feeRate
-  return fee
-}
-
 export function toXOnly(pubkey: Buffer): Buffer {
   return pubkey.subarray(1, 33)
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -95,19 +95,24 @@ export function calculateTxFee({
   totalOutputs,
   satsPerByte,
   type,
-  additional = {}
+  additional: { witnessScripts = [] } = {}
 }: CalculateTxFeeOptions): number {
-  const txWeight = calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional })
+  const txWeight = calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional: { witnessScripts } })
   return txWeight * satsPerByte
 }
 
-export function calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional }: CalculateTxVirtualSizeOptions) {
+export function calculateTxVirtualSize({
+  totalInputs,
+  totalOutputs,
+  type,
+  additional: { witnessScripts = [] } = {}
+}: CalculateTxVirtualSizeOptions) {
   const baseWeight = getInputOutputBaseSizeByType(type)
 
   const inputVBytes = baseWeight.input * totalInputs
   const outputVBytes = baseWeight.output * totalOutputs
   const baseVBytes = inputVBytes + outputVBytes + baseWeight.txHeader
-  const additionalVBytes = additional?.witnessScripts?.reduce((acc, script) => (acc += script.byteLength), 0) || 0
+  const additionalVBytes = witnessScripts.reduce((acc, script) => (acc += script.byteLength), 0) || 0
 
   const weight = 3 * baseVBytes + (baseVBytes + additionalVBytes)
   const vSize = Math.ceil(weight / 4)

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -117,20 +117,20 @@ export function calculateTxFee({
 }
 
 export function calculateTxVirtualSize({ totalInputs, totalOutputs, type, additional }: CalculateTxVirtualSizeOptions) {
-  const baseWeight = getInputOutputBaseWeightByType(type)
+  const baseWeight = getInputOutputBaseSizeByType(type)
 
   const inputVBytes = baseWeight.input * totalInputs
   const outputVBytes = baseWeight.output * totalOutputs
   const baseVBytes = inputVBytes + outputVBytes + baseWeight.txHeader
-  const additionalVBytes =
-    additional && Buffer.isBuffer(additional?.witnessScript) ? additional.witnessScript.byteLength : 0
+  const additionalVBytes = additional?.witnessScripts?.reduce((acc, script) => (acc += script.byteLength), 0) || 0
+
   const weight = 3 * baseVBytes + (baseVBytes + additionalVBytes)
   const vSize = Math.ceil(weight / 4)
 
   return vSize
 }
 
-export function getInputOutputBaseWeightByType(type: AddressFormats) {
+export function getInputOutputBaseSizeByType(type: AddressFormats) {
   switch (type) {
     case "taproot":
       return { input: 57.5, output: 43, txHeader: 10.5 }

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -1,0 +1,13 @@
+import { AddressFormats } from "../addresses/formats"
+
+export interface CalculateTxFeeOptions {
+  totalInputs: number
+  totalOutputs: number
+  satsPerByte: number
+  type: AddressFormats
+  additional?: {
+    witnessScript?: Buffer
+  }
+}
+
+export type CalculateTxWeightOptions = Omit<CalculateTxFeeOptions, "satsPerByte">

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -6,7 +6,7 @@ export interface CalculateTxFeeOptions {
   satsPerByte: number
   type: AddressFormats
   additional?: {
-    witnessScript?: Buffer
+    witnessScripts?: Buffer[]
   }
 }
 

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -10,4 +10,4 @@ export interface CalculateTxFeeOptions {
   }
 }
 
-export type CalculateTxWeightOptions = Omit<CalculateTxFeeOptions, "satsPerByte">
+export type CalculateTxVirtualSizeOptions = Omit<CalculateTxFeeOptions, "satsPerByte">

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -11,7 +11,7 @@ import {
   AddressFormats,
   addressNameToType,
   generateBuyerPsbt,
-  generateDummyUtxos,
+  generateRefundableUTXOs,
   generateSellerPsbt,
   getAccountDataFromHdNode,
   getAddressesFromPublicKey,
@@ -287,8 +287,8 @@ export class Ordit {
   static instantBuy = {
     generateBuyerPsbt,
     generateSellerPsbt,
-    generateDummyUtxos
-  };
+    generateRefundableUTXOs
+  }
 
   static collection = {
     publish: publishCollection,

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -152,7 +152,7 @@ export class Ordit {
     });
   }
 
-  signPsbt(value: string, { finalized = true, tweak = false }: SignPSBTOptions = {}) {
+  signPsbt(value: string, { finalize = true, extractTx = true, isRevealTx = false }: SignPSBTOptions = {}) {
     const networkObj = getNetwork(this.#network);
     let psbt: bitcoin.Psbt | null = null;
 
@@ -188,7 +188,7 @@ export class Ordit {
         const address = bitcoin.address.fromOutputScript(script, networkObj);
 
         // TODO: improvise the below logic by accepting indexes to sign
-        if (!tweak || (tweak && this.selectedAddress === address)) {
+        if (isRevealTx || (!isRevealTx && this.selectedAddress === address)) {
           inputsToSign.push({
             index,
             publicKey: this.publicKey,
@@ -216,7 +216,8 @@ export class Ordit {
             network: networkObj
           });
 
-          const signer = tweak ? tweakedSigner : this.#keyPair;
+          const signer =
+            input.witnessUtxo?.script && input.tapInternalKey && !input.tapLeafScript ? tweakedSigner : this.#keyPair
 
           psbt.signInput(inputsToSign[i].index, signer, inputsToSign[i].sighashTypes);
         } else {
@@ -227,17 +228,16 @@ export class Ordit {
       }
     }
 
-    const psbtHex = psbt.toHex();
-
-    if (finalized) {
-      psbt.finalizeAllInputs();
-
-      const signedHex = psbt.extractTransaction().toHex();
-
-      return signedHex;
+    // TODO: check if psbt has been signed
+    if (finalize) {
+      psbt.finalizeAllInputs()
     }
 
-    return psbtHex;
+    if (extractTx) {
+      return psbt.extractTransaction().toHex()
+    }
+
+    return psbt.toHex()
   }
 
   signMessage(message: string) {

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -324,6 +324,7 @@ export interface Input {
 }
 
 export interface SignPSBTOptions {
-  finalized?: boolean;
-  tweak?: boolean;
+  extractTx?: boolean
+  finalize?: boolean
+  isRevealTx?: boolean
 }

--- a/packages/sdk/src/wallet/index.ts
+++ b/packages/sdk/src/wallet/index.ts
@@ -1,8 +1,10 @@
-import { getAddressesFromPublicKey } from "../addresses";
-import { AddressTypes } from "../addresses/formats";
-import { OrditApi } from "../api";
-import { Network } from "../config/types";
-import { getWalletKeys } from "../keys";
+import { getAddressesFromPublicKey } from "../addresses"
+import { AddressTypes } from "../addresses/formats"
+import { OrditApi } from "../api"
+import { Network } from "../config/types"
+import { Inscription, Ordinal } from "../inscription/types"
+import { getWalletKeys } from "../keys"
+import { UTXO } from "../transactions/types"
 
 export async function getWallet({
   pubKey,
@@ -23,10 +25,10 @@ export async function getWallet({
 export async function getWalletWithBalances({ pubKey, format, network, safeMode = "on" }: GetWalletOptions) {
   const wallet = (await getWallet({ pubKey, format, network })) as GetWalletWithBalances;
 
-  const ordinals: unknown[] = [];
-  const inscriptions: unknown[] = [];
-  const spendables: unknown[] = [];
-  const unspendables: unknown[] = [];
+  const ordinals: Ordinal[] = []
+  const inscriptions: Inscription[] = []
+  const spendables: UTXO[] = []
+  const unspendables: UTXO[] = []
 
   wallet.counts.unspents = 0;
   wallet.counts.satoshis = 0;
@@ -129,10 +131,10 @@ export type GetWalletReturnType = {
 };
 
 export type GetWalletWithBalances = GetWalletReturnType & {
-  spendables: unknown[];
-  unspendables: unknown[];
-  ordinals: unknown[];
-  inscriptions: unknown[];
+  spendables: UTXO[]
+  unspendables: UTXO[]
+  ordinals: Ordinal[]
+  inscriptions: Inscription[]
 
   counts: {
     unspents: number;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR calculates the tx fees based on actual input and output bytes wrt. to the tx type (p2tr, p2wpkh, etc.). Earlier, the calculation was done on an arbitrary number of 180 that closely aligns w/ legacy input bytes. Following are the references for the hardcoded input and output bytes:

1. [bitcoinops.org](https://bitcoinops.org/en/tools/calc-size/) - tx size calculator
2. [Answer](https://bitcoin.stackexchange.com/a/87276/143085) by Pieter Wuille on bitcoin.stackenchange.com (Co-author of BIP-141)

Additionally, the following bug fixes and improvements have been tagged along w/ this PR: 
1. Disable semicolon in Prettier config
2. Lint all changed files
3. Remove intentional suppressing of error or unnecessary `try..catch` blocks
4. Add new and improvise existing code examples
5. Fix psbt creation for legacy address