### PR TITLE
feat(sdk): encode inscription `meta` values

### DIFF
--- a/examples/node/inscribe.js
+++ b/examples/node/inscribe.js
@@ -45,7 +45,7 @@ async function main() {
     transaction.build();
 
     // sign transaction
-    const signature = wallet.signPsbt(transaction.toHex());
+    const signature = wallet.signPsbt(transaction.toHex(), { isRevealTx: true });
 
     // Broadcast transaction
     const tx = await wallet.relayTx(signature, "testnet");

--- a/packages/sdk/src/inscription/commit.ts
+++ b/packages/sdk/src/inscription/commit.ts
@@ -1,5 +1,5 @@
 import { getAddresses } from "../addresses"
-import { createTransaction } from "../utils"
+import { createTransaction, encodeObject } from "../utils"
 import { GetWalletOptions } from "../wallet"
 import { buildWitnessScript } from "./witness"
 
@@ -9,7 +9,7 @@ export async function generateCommitAddress(options: GenerateCommitAddressOption
   const xkey = key.xkey
 
   if (xkey) {
-    const witnessScript = buildWitnessScript({ ...options, xkey })
+    const witnessScript = buildWitnessScript({ ...options, xkey, meta: encodeObject(options.meta) })
 
     if (!witnessScript) {
       throw new Error("Failed to build witness script.")

--- a/packages/sdk/src/inscription/psbt.ts
+++ b/packages/sdk/src/inscription/psbt.ts
@@ -3,7 +3,7 @@ import { Psbt } from "bitcoinjs-lib"
 import { getAddresses } from "../addresses"
 import { OrditApi } from "../api"
 import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
-import { createTransaction, getNetwork } from "../utils"
+import { createTransaction, encodeObject, getNetwork } from "../utils"
 import { GetWalletOptions } from "../wallet"
 import { buildWitnessScript } from "./witness"
 
@@ -18,7 +18,7 @@ export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
     throw new Error("Failed to build createRevealPsbt");
   }
 
-  const witnessScript = buildWitnessScript({ ...options, xkey });
+  const witnessScript = buildWitnessScript({ ...options, xkey, meta: encodeObject(options.meta) })
 
   if (!witnessScript) {
     throw new Error("Failed to build createRevealPsbt");

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -6,6 +6,7 @@ import {
   buildWitnessScript,
   calculateTxFee,
   createTransaction,
+  encodeObject,
   getAddressesFromPublicKey,
   getNetwork,
   GetWalletOptions,
@@ -14,6 +15,7 @@ import {
 } from ".."
 import { Network } from "../config/types"
 import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
+import { NestedObject } from "../utils/types"
 
 bitcoin.initEccLib(ecc)
 
@@ -25,7 +27,7 @@ export class OrdTransaction {
   mediaContent: string
   destinationAddress: string
   changeAddress: string
-  meta: object | unknown
+  meta?: NestedObject
   network: Network
   psbt: bitcoin.Psbt | null = null
   ready = false
@@ -173,13 +175,13 @@ export class OrdTransaction {
     const witnessScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta,
+      meta: this.meta ? encodeObject(this.meta) : null,
       xkey: this.#xKey
     })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta,
+      meta: this.meta ? encodeObject(this.meta) : null,
       xkey: this.#xKey,
       recover: true
     })
@@ -238,13 +240,13 @@ export class OrdTransaction {
     const witnessScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta,
+      meta: this.meta ? encodeObject(this.meta) : null,
       xkey: this.#xKey
     })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta,
+      meta: this.meta ? encodeObject(this.meta) : null,
       xkey: this.#xKey,
       recover: true
     })
@@ -333,7 +335,7 @@ export type OrdTransactionOptions = Pick<GetWalletOptions, "safeMode"> & {
   mediaContent: string
   destination: string
   changeAddress: string
-  meta?: object | unknown
+  meta?: NestedObject
   network?: Network
   publicKey: string
   outs?: Outputs

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -11,3 +11,12 @@ export interface CalculateTxFeeOptions {
 }
 
 export type CalculateTxVirtualSizeOptions = Omit<CalculateTxFeeOptions, "satsPerByte">
+
+export interface NestedObject {
+  [key: string]: NestedObject | any
+}
+
+export interface EncodeDecodeObjectOptions {
+  encode: boolean
+  depth?: number
+}


### PR DESCRIPTION
This PR fixes the issue of inscription tx failure by encoding the values of `meta`. Properties including but not limited to `title` / `description` can potentially have non-utf8 characters and the SDK should properly encode it before inscribing it on-chain.

The package consumers are supposed to decode the `meta` object recursively on their end. [Functions from this PR](https://github.com/sadoprotocol/ordit-sdk/pull/32/files#diff-9253a4b03ec0ce7e7bb72d41d6d289076a5341c18445510ffbcb645a7adaa70cR145-R172) can be used to decode.

Also, a fix has been added to inscribe example.