### PR TITLE
fix(sdk)!: add missing address type to input generator

### DIFF
--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -102,7 +102,7 @@ export async function processInput({
       return generateTaprootInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })
 
     case "witness_v0_scripthash":
-      return generateSegwitInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })
+    case "witness_v0_keyhash":
 
     case "scripthash":
       return generateNestedSegwitInput({ utxo, pubKey, network, rawTx, enableRBF, ...options })


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the input generator by adding the missing `witness_v0_keyhash` type for nested segwit txs. Also, a few improvements to the input generator have been added in this PR.

#### BREAKING CHANGES
- Renamed multiple argument options properties
- Removed `satsPerByte = 10` default value from args of `createPsbt` fn

#### Refactor & Fixes
- Move RBF enabling logic to higher level