### PR TITLE
refactor(sdk): set metadata encoding optional

### DIFF
--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -1,14 +1,15 @@
-import { Transaction as BTCTransaction } from 'bitcoinjs-lib'
+import { Transaction as BTCTransaction } from "bitcoinjs-lib"
 
-import { Network } from "../config/types";
-import { Rarity } from "../inscription/types";
-import { Transaction, UTXO } from "../transactions/types";
+import { Network } from "../config/types"
+import { Rarity } from "../inscription/types"
+import { Transaction, UTXO } from "../transactions/types"
 
 export interface FetchUnspentUTXOsOptions {
   address: string
   network?: Network
   type?: "all" | "spendable"
   rarity?: Rarity[]
+  decodeMetadata?: boolean
 }
 
 export interface FetchUnspentUTXOsResponse {
@@ -23,6 +24,7 @@ export interface FetchTxOptions {
   ordinals?: boolean
   hex?: boolean
   witness?: boolean
+  decodeMetadata?: boolean
 }
 
 export interface FetchTxResponse {
@@ -33,6 +35,7 @@ export interface FetchTxResponse {
 export interface FetchInscriptionsOptions {
   outpoint: string
   network?: Network
+  decodeMetadata?: boolean
 }
 
 export interface RelayTxOptions {

--- a/packages/sdk/src/inscription/commit.ts
+++ b/packages/sdk/src/inscription/commit.ts
@@ -4,12 +4,16 @@ import { GetWalletOptions } from "../wallet"
 import { buildWitnessScript } from "./witness"
 
 export async function generateCommitAddress(options: GenerateCommitAddressOptions) {
-  const { satsPerByte = 10, network, pubKey } = options
+  const { satsPerByte = 10, network, pubKey, encodeMetadata = false } = options
   const key = (await getAddresses({ pubKey, network, format: "p2tr" }))[0]
   const xkey = key.xkey
 
   if (xkey) {
-    const witnessScript = buildWitnessScript({ ...options, xkey, meta: encodeObject(options.meta) })
+    const witnessScript = buildWitnessScript({
+      ...options,
+      xkey,
+      meta: options.meta && encodeMetadata ? encodeObject(options.meta) : options.meta
+    })
 
     if (!witnessScript) {
       throw new Error("Failed to build witness script.")
@@ -41,4 +45,5 @@ export type GenerateCommitAddressOptions = Omit<GetWalletOptions, "format" | "sa
   mediaType: string
   mediaContent: string
   meta: any
+  encodeMetadata?: boolean
 }

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -328,7 +328,6 @@ export interface GenerateBuyerInstantBuyPsbtOptions {
 }
 
 export interface GenerateRefundableUTXOsOptions {
-  value: number
   count?: number
   publicKey: string
   pubKeyType: AddressFormats

--- a/packages/sdk/src/inscription/psbt.ts
+++ b/packages/sdk/src/inscription/psbt.ts
@@ -8,17 +8,22 @@ import { GetWalletOptions } from "../wallet"
 import { buildWitnessScript } from "./witness"
 
 export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
-  const networkObj = getNetwork(options.network);
-  const key = (await getAddresses({ ...options, format: "p2tr" }))[0];
-  const xkey = key.xkey;
-  
-  options.safeMode = !options.safeMode ? "on": options.safeMode
+  const networkObj = getNetwork(options.network)
+  const key = (await getAddresses({ ...options, format: "p2tr" }))[0]
+  const xkey = key.xkey
+  const { encodeMetadata = false } = options
+
+  options.safeMode = !options.safeMode ? "on" : options.safeMode
 
   if (!xkey) {
     throw new Error("Failed to build createRevealPsbt");
   }
 
-  const witnessScript = buildWitnessScript({ ...options, xkey, meta: encodeObject(options.meta) })
+  const witnessScript = buildWitnessScript({
+    ...options,
+    xkey,
+    meta: options.meta && encodeMetadata ? encodeObject(options.meta) : options.meta
+  })
 
   if (!witnessScript) {
     throw new Error("Failed to build createRevealPsbt");
@@ -95,11 +100,12 @@ export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
 }
 
 export type CreateRevealPsbtOptions = Omit<GetWalletOptions, "format"> & {
-  fees: number;
-  postage: number;
-  mediaType: string;
-  mediaContent: string;
-  destination: string;
-  changeAddress: string;
-  meta: any;
-};
+  fees: number
+  postage: number
+  mediaType: string
+  mediaContent: string
+  destination: string
+  changeAddress: string
+  meta: any
+  encodeMetadata?: boolean
+}

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -39,6 +39,7 @@ export class OrdTransaction {
   #recovery = false
   #outs: Outputs = []
   #safeMode: OnOffUnion
+  #encodeMetadata: boolean
 
   constructor({
     feeRate = 10,
@@ -47,6 +48,7 @@ export class OrdTransaction {
     network = "testnet",
     publicKey,
     outs = [],
+    encodeMetadata = false,
     ...otherOptions
   }: OrdTransactionOptions) {
     if (!publicKey || !otherOptions.changeAddress || !otherOptions.destination || !otherOptions.mediaContent) {
@@ -64,6 +66,7 @@ export class OrdTransaction {
     this.postage = postage
     this.#outs = outs
     this.#safeMode = !otherOptions.safeMode ? "on" : otherOptions.safeMode
+    this.#encodeMetadata = encodeMetadata
 
     const xKey = getAddressesFromPublicKey(publicKey, network, "p2tr")[0].xkey
 
@@ -175,13 +178,13 @@ export class OrdTransaction {
     const witnessScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta ? encodeObject(this.meta) : null,
+      meta: this.meta && this.#encodeMetadata ? encodeObject(this.meta) : this.meta,
       xkey: this.#xKey
     })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta ? encodeObject(this.meta) : null,
+      meta: this.meta && this.#encodeMetadata ? encodeObject(this.meta) : this.meta,
       xkey: this.#xKey,
       recover: true
     })
@@ -240,13 +243,13 @@ export class OrdTransaction {
     const witnessScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta ? encodeObject(this.meta) : null,
+      meta: this.meta && this.#encodeMetadata ? encodeObject(this.meta) : this.meta,
       xkey: this.#xKey
     })
     const recoverScript = buildWitnessScript({
       mediaContent: this.mediaContent,
       mediaType: this.mediaType,
-      meta: this.meta ? encodeObject(this.meta) : null,
+      meta: this.meta && this.#encodeMetadata ? encodeObject(this.meta) : this.meta,
       xkey: this.#xKey,
       recover: true
     })
@@ -339,6 +342,7 @@ export type OrdTransactionOptions = Pick<GetWalletOptions, "safeMode"> & {
   network?: Network
   publicKey: string
   outs?: Outputs
+  encodeMetadata?: boolean
 }
 
 type Outputs = Array<{ address: string; value: number }>


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR sets metadata encoding optional and decodes all metadata retrieved via RPC calls by default w/ an option to disable decoding.

Also, an unused arg option has been removed from the interface.