### PR TITLE
refactor(sdk): integrate `GetSpendables` API & improvements

### DIFF
--- a/examples/node/create-psbt.js
+++ b/examples/node/create-psbt.js
@@ -11,10 +11,8 @@ async function main() {
 
     const psbt = await ordit.transactions.createPsbt({
         pubKey: '039ce27aa7666731648421004ba943b90b8273e23a175d9c58e3ec2e643a9b01d1',
-        ins: [{
-            address: 'tb1p98dv6f5jp5qr4z2dtaljvwrhq34xrr8zuaqgv4ajf36vg2mmsruqt5m3lv'
-        }],
-        outs: [{
+        address: 'tb1p98dv6f5jp5qr4z2dtaljvwrhq34xrr8zuaqgv4ajf36vg2mmsruqt5m3lv',
+        outputs: [{
             address: 'tb1qatkgzm0hsk83ysqja5nq8ecdmtwl73zwurawww',
             cardinals: 1200
         }],

--- a/examples/node/instant-buy.js
+++ b/examples/node/instant-buy.js
@@ -54,22 +54,13 @@ async function createBuyOrder({ sellerPSBT }) {
 }
 
 async function checkForExistingRefundableUTXOs(address) {
-    const response = await OrditApi.fetch('/utxo/unspents', {
-        data: {
-            address: address,
-            options: {
-                txhex: true,
-                notsafetospend: false,
-                allowedrarity: ["common"]
-            }
-        },
+    const { spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({
+        address,
         network: 'testnet'
     })
 
-    const utxos = response.rdata
-    const filteredUTXOs = utxos
-        .filter(utxo => utxo.safeToSpend && !utxo.inscriptions.length && utxo.sats > 600 && utxo.sats <= 1000)
-        .sort((a, b) => a.sats - b.sats) // Sort by lowest value utxo to highest such that we spend only the ones that are lowest
+    const filteredUTXOs = spendableUTXOs
+        .filter(utxo => utxo.sats > 600)
 
     if(filteredUTXOs.length < 2) {
         throw new Error("Not enough UTXOs in 600-1000 sats range. Use Ordit.instantBuy.generateDummyUtxos() to generate dummy utxos.")

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -30,7 +30,8 @@ export class OrditApi {
     network = "testnet",
     type = "spendable",
     rarity = ["common"],
-    decodeMetadata = true
+    decodeMetadata = true,
+    sort = "desc"
   }: FetchUnspentUTXOsOptions): Promise<FetchUnspentUTXOsResponse> {
     if (!address) {
       throw new Error("Invalid address")
@@ -45,9 +46,9 @@ export class OrditApi {
           safetospend: type === "spendable"
         },
         pagination: {
-          page: 1,
           limit: 50
-        }
+        },
+        sort: { value: sort }
       },
       rpc.id
     )

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -14,6 +14,7 @@ import {
   FetchTxResponse,
   FetchUnspentUTXOsOptions,
   FetchUnspentUTXOsResponse,
+  GetBalanceOptions,
   RelayTxOptions
 } from "./types"
 
@@ -212,5 +213,21 @@ export class OrditApi {
       },
       rpc.id
     )
+  }
+
+  static async getBalance({ address, network = "testnet" }: GetBalanceOptions) {
+    if (!address) {
+      throw new Error("Invalid request")
+    }
+
+    const balance = await rpc[network].call<number>(
+      "GetBalance",
+      {
+        address
+      },
+      rpc.id
+    )
+
+    return balance
   }
 }

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -173,7 +173,8 @@ export class OrditApi {
     rarity = ["common"],
     filter = [],
     limit = 200,
-    network = "testnet"
+    network = "testnet",
+    type = "spendable"
   }: FetchSpendablesOptions) {
     if (!address || !value) {
       throw new Error("Invalid options provided")
@@ -184,6 +185,7 @@ export class OrditApi {
       {
         address,
         value,
+        safetospend: type === "spendable",
         allowedrarity: rarity,
         filter,
         limit

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -3,12 +3,13 @@ import * as bitcoin from "bitcoinjs-lib"
 import { apiConfig } from "../config"
 import { Network } from "../config/types"
 import { Inscription } from "../inscription/types"
-import { Transaction, UTXO } from "../transactions/types"
+import { Transaction, UTXO, UTXOLimited } from "../transactions/types"
 import { decodeObject } from "../utils"
 import { rpc } from "./jsonrpc"
 import {
   FetchInscriptionOptions,
   FetchInscriptionsOptions,
+  FetchSpendablesOptions,
   FetchTxOptions,
   FetchTxResponse,
   FetchUnspentUTXOsOptions,
@@ -164,6 +165,31 @@ export class OrditApi {
     inscription.meta = inscription.meta && decodeMetadata ? decodeObject(inscription.meta) : inscription.meta
 
     return inscription
+  }
+
+  static async fetchSpendables({
+    address,
+    value,
+    rarity = ["common"],
+    filter = [],
+    limit = 200,
+    network = "testnet"
+  }: FetchSpendablesOptions) {
+    if (!address || !value) {
+      throw new Error("Invalid options provided")
+    }
+
+    return rpc[network].call<UTXOLimited[]>(
+      "GetSpendables",
+      {
+        address,
+        value,
+        allowedrarity: rarity,
+        filter,
+        limit
+      },
+      rpc.id
+    )
   }
 
   static async relayTx({ hex, network = "testnet", maxFeeRate }: RelayTxOptions): Promise<string> {

--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -10,6 +10,7 @@ export interface FetchUnspentUTXOsOptions {
   type?: "all" | "spendable"
   rarity?: Rarity[]
   decodeMetadata?: boolean
+  sort?: "asc" | "desc"
 }
 
 export interface FetchUnspentUTXOsResponse {
@@ -57,5 +58,10 @@ export interface FetchSpendablesOptions {
   rarity?: Rarity[]
   filter?: string[]
   limit?: number
+  network?: Network
+}
+
+export interface GetBalanceOptions {
+  address: string
   network?: Network
 }

--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -49,3 +49,12 @@ export interface RelayTxOptions {
   maxFeeRate?: number
   network?: Network
 }
+
+export interface FetchSpendablesOptions {
+  address: string
+  value: number
+  rarity?: Rarity[]
+  filter?: string[]
+  limit?: number
+  network?: Network
+}

--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -53,6 +53,7 @@ export interface RelayTxOptions {
 export interface FetchSpendablesOptions {
   address: string
   value: number
+  type?: "all" | "spendable"
   rarity?: Rarity[]
   filter?: string[]
   limit?: number

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -3,7 +3,7 @@ import { Psbt } from "bitcoinjs-lib"
 import { UnisatSignPSBTOptions } from "./types"
 import { isUnisatInstalled } from "./utils"
 
-export async function signPsbt(psbt: Psbt, { finalize = true }: UnisatSignPSBTOptions = {}) {
+export async function signPsbt(psbt: Psbt, { finalize = true, extractTx = true }: UnisatSignPSBTOptions = {}) {
   if (!isUnisatInstalled()) {
     throw new Error("Unisat not installed.")
   }
@@ -21,9 +21,9 @@ export async function signPsbt(psbt: Psbt, { finalize = true }: UnisatSignPSBTOp
   }
 
   const signedPsbt = Psbt.fromHex(signedPsbtHex)
-  let rawTxHex = null
+  let rawTxHex: string | null = null
   try {
-    rawTxHex = signedPsbt.extractTransaction().toHex()
+    rawTxHex = extractTx ? signedPsbt.extractTransaction().toHex() : signedPsbt.toHex()
   } catch (error) {
     return {
       rawTxHex,

--- a/packages/sdk/src/browser-wallets/unisat/types.ts
+++ b/packages/sdk/src/browser-wallets/unisat/types.ts
@@ -1,3 +1,4 @@
 export interface UnisatSignPSBTOptions {
   finalize?: boolean
+  extractTx?: boolean
 }

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -5,6 +5,7 @@ import {
   addressNameToType,
   AddressTypes,
   calculateTxFee,
+  convertBTCToSatoshis,
   getAddressesFromPublicKey,
   getNetwork,
   InputType,
@@ -72,7 +73,7 @@ export async function generateBuyerPsbt({
     throw new Error("Outpoint not found.")
   }
 
-  postage = parseInt((output.value * 1e8).toString())
+  postage = convertBTCToSatoshis(output.value)
 
   const { totalUTXOs, spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ address: address.address!, network })
   if (!totalUTXOs) {

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -55,28 +55,24 @@ export async function generateBuyerPsbt({
   let ordOutNumber = 0
   // get postage from outpoint
 
-  try {
-    const [ordTxId, ordOut] = inscriptionOutPoint.split(":")
-    if (!ordTxId || !ordOut) {
-      throw new Error("Invalid outpoint.")
-    }
-
-    ordOutNumber = parseInt(ordOut)
-    const { tx } = await OrditApi.fetchTx({ txId: ordTxId, network })
-    if (!tx) {
-      throw new Error("Failed to get raw transaction for id: " + ordTxId)
-    }
-
-    const output = tx && tx.vout[ordOutNumber]
-
-    if (!output) {
-      throw new Error("Outpoint not found.")
-    }
-
-    postage = parseInt((output.value * 1e8).toString())
-  } catch (error) {
-    throw new Error(error.message)
+  const [ordTxId, ordOut] = inscriptionOutPoint.split(":")
+  if (!ordTxId || !ordOut) {
+    throw new Error("Invalid outpoint.")
   }
+
+  ordOutNumber = parseInt(ordOut)
+  const { tx } = await OrditApi.fetchTx({ txId: ordTxId, network })
+  if (!tx) {
+    throw new Error("Failed to get raw transaction for id: " + ordTxId)
+  }
+
+  const output = tx && tx.vout[ordOutNumber]
+
+  if (!output) {
+    throw new Error("Outpoint not found.")
+  }
+
+  postage = parseInt((output.value * 1e8).toString())
 
   const { totalUTXOs, spendableUTXOs } = await OrditApi.fetchUnspentUTXOs({ address: address.address!, network })
   if (!totalUTXOs) {

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -256,7 +256,7 @@ export async function getSellerInputsOutputs({
   const format = addressNameToType[pubKeyType]
   const address = getAddressesFromPublicKey(publicKey, network, format)[0]
   const inputs: InputType[] = []
-  const outputs = []
+  const outputs: { address: string; value: number }[] = []
 
   const { totalUTXOs, unspendableUTXOs } = await OrditApi.fetchUnspentUTXOs({
     address: address.address!,

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -6,6 +6,7 @@ import {
   AddressTypes,
   calculateTxFee,
   convertBTCToSatoshis,
+  generateTxUniqueIdentifier,
   getAddressesFromPublicKey,
   getNetwork,
   InputType,
@@ -93,11 +94,11 @@ export async function generateBuyerPsbt({
   const refundableUTXOs = [utxos[0]].concat(utxos[1])
   for (let i = 0; i < refundableUTXOs.length; i++) {
     const refundableUTXO = refundableUTXOs[i]
-    if (usedUTXOTxIds.includes(refundableUTXO.txid)) continue
+    if (usedUTXOTxIds.includes(generateTxUniqueIdentifier(refundableUTXO.txid, refundableUTXO.n))) continue
 
     const input = await processInput({ utxo: refundableUTXO, pubKey: publicKey, network })
 
-    usedUTXOTxIds.push(input.hash)
+    usedUTXOTxIds.push(generateTxUniqueIdentifier(input.hash, input.index))
     psbt.addInput(input)
     totalInput += refundableUTXO.sats
   }
@@ -126,12 +127,12 @@ export async function generateBuyerPsbt({
 
   for (let i = 0; i < utxos.length; i++) {
     const utxo = utxos[i]
-    if (usedUTXOTxIds.includes(utxo.txid)) continue
+    if (usedUTXOTxIds.includes(generateTxUniqueIdentifier(utxo.txid, utxo.n))) continue
 
     const input = await processInput({ utxo, pubKey: publicKey, network })
     input.witnessUtxo?.script && witnessScripts.push(input.witnessUtxo?.script)
 
-    usedUTXOTxIds.push(input.hash)
+    usedUTXOTxIds.push(generateTxUniqueIdentifier(input.hash, input.index))
 
     psbt.addInput(input)
     totalInput += utxo.sats

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -52,7 +52,6 @@ export async function generateBuyerPsbt({
   const networkObj = getNetwork(network)
   const format = addressNameToType[pubKeyType]
   const address = getAddressesFromPublicKey(publicKey, network, format)[0]
-  let postage = 10000 // default postage
   let ordOutNumber = 0
   // get postage from outpoint
 
@@ -73,8 +72,7 @@ export async function generateBuyerPsbt({
     throw new Error("Outpoint not found.")
   }
 
-  postage = convertBTCToSatoshis(output.value)
-
+  const postage = convertBTCToSatoshis(output.value)
   const utxos = (
     await OrditApi.fetchUnspentUTXOs({
       address: address.address!,

--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -89,7 +89,7 @@ export async function generateBuyerPsbt({
   }
 
   const psbt = new bitcoin.Psbt({ network: networkObj })
-  let totalInput = 0
+  let totalInput = postage
   const witnessScripts: Buffer[] = []
   const usedUTXOTxIds: string[] = []
   const refundableUTXOs = [utxos[0]].concat(utxos[1])

--- a/packages/sdk/src/inscription/psbt.ts
+++ b/packages/sdk/src/inscription/psbt.ts
@@ -3,7 +3,7 @@ import { Psbt } from "bitcoinjs-lib"
 import { getAddresses } from "../addresses"
 import { OrditApi } from "../api"
 import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
-import { createTransaction, encodeObject, getNetwork } from "../utils"
+import { convertSatoshisToBTC, createTransaction, encodeObject, getNetwork } from "../utils"
 import { GetWalletOptions } from "../wallet"
 import { buildWitnessScript } from "./witness"
 
@@ -48,7 +48,7 @@ export async function createRevealPsbt(options: CreateRevealPsbtOptions) {
   const utxos = await OrditApi.fetchSpendables({
     address: inscribePayTx.address!,
     network: options.network,
-    value: totalAmount,
+    value: convertSatoshisToBTC(totalAmount),
     type: options.safeMode === "on" ? "spendable" : "all"
   })
 

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -308,7 +308,8 @@ export class OrdTransaction {
     const utxos = await OrditApi.fetchSpendables({
       address: this.#commitAddress,
       value: amount,
-      network: this.network
+      network: this.network,
+      type: this.#safeMode === "on" ? "spendable" : "all"
     })
 
     const suitableUTXO = utxos.find((utxo) => utxo.value === amount)

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -5,6 +5,7 @@ import { Tapleaf } from "bitcoinjs-lib/src/types"
 import {
   buildWitnessScript,
   calculateTxFee,
+  convertSatoshisToBTC,
   createTransaction,
   encodeObject,
   getAddressesFromPublicKey,
@@ -307,7 +308,7 @@ export class OrdTransaction {
 
     const utxos = await OrditApi.fetchSpendables({
       address: this.#commitAddress,
-      value: amount,
+      value: convertSatoshisToBTC(amount),
       network: this.network,
       type: this.#safeMode === "on" ? "spendable" : "all"
     })

--- a/packages/sdk/src/transactions/types.ts
+++ b/packages/sdk/src/transactions/types.ts
@@ -69,3 +69,5 @@ export interface UTXO {
   safeToSpend: boolean
   confirmation: number
 }
+
+export type UTXOLimited = Pick<UTXO, "txid" | "n" | "value" | "sats" | "scriptPubKey">

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -170,3 +170,12 @@ export function encodeObject(obj: NestedObject) {
 export function decodeObject(obj: NestedObject) {
   return encodeDecodeObject(obj, { encode: false })
 }
+
+// Temporary convertors until bignumber.js is integrated
+export function convertSatoshisToBTC(satoshis: number) {
+  return satoshis / 10 ** 8
+}
+
+export function convertBTCToSatoshis(btc: number) {
+  return parseInt((btc * 10 ** 8).toString()) // remove floating point overflow by parseInt
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -179,3 +179,7 @@ export function convertSatoshisToBTC(satoshis: number) {
 export function convertBTCToSatoshis(btc: number) {
   return parseInt((btc * 10 ** 8).toString()) // remove floating point overflow by parseInt
 }
+
+export function generateTxUniqueIdentifier(txId: string, index: number) {
+  return `${txId}:${index}`
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds multiple improvements, refactors, and fixes. Following are the changes:

1. Replace `GetUnspents` w/ `GetSpendables` API to improve performance wherever the final value is known
2. Add util method to convert Satoshis to BTC and vice-versa
3. Add `sort` option to `GetUnspents` API
4. Add postage amount to total input amount calculation in instant buy-sell flow
5. Add API to get balance for address
6. Extend Unisat and Xverse signature wrapper to accept `finalize` and `extractTx` options
7. Fixed message format for verifiable ordinals per OIP-2 standards