### PR TITLE
feat(sdk): add util methods to decode PSBT and tx

### DIFF
--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -5,7 +5,14 @@ import ECPairFactory from "ecpair"
 
 import { AddressFormats, AddressTypes } from "../addresses/formats"
 import { Network } from "../config/types"
-import { CalculateTxFeeOptions, CalculateTxVirtualSizeOptions, EncodeDecodeObjectOptions, NestedObject } from "./types"
+import {
+  BufferOrHex,
+  CalculateTxFeeOptions,
+  CalculateTxVirtualSizeOptions,
+  EncodeDecodeObjectOptions,
+  NestedObject,
+  OneOfAllDataFormats
+} from "./types"
 
 export function getNetwork(value: Network) {
   if (value === "mainnet") {
@@ -182,4 +189,19 @@ export function convertBTCToSatoshis(btc: number) {
 
 export function generateTxUniqueIdentifier(txId: string, index: number) {
   return `${txId}:${index}`
+}
+
+export function decodePSBT({ hex, base64, buffer }: OneOfAllDataFormats): bitcoin.Psbt {
+  if (hex) return bitcoin.Psbt.fromHex(hex)
+  if (base64) return bitcoin.Psbt.fromBase64(base64)
+  if (buffer) return bitcoin.Psbt.fromBuffer(buffer)
+
+  throw new Error("Invalid options")
+}
+
+export function decodeTx({ hex, buffer }: BufferOrHex): bitcoin.Transaction {
+  if (hex) return bitcoin.Transaction.fromHex(hex)
+  if (buffer) return bitcoin.Transaction.fromBuffer(buffer)
+
+  throw new Error("Invalid options")
 }

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -26,3 +26,11 @@ export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclu
     [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
   }[Keys]
 
+interface BaseDataFormat {
+  hex?: string
+  base64?: string
+  buffer?: Buffer
+}
+
+export type OneOfAllDataFormats = RequireAtLeastOne<BaseDataFormat, "base64" | "buffer" | "hex">
+export type BufferOrHex = RequireAtLeastOne<BaseDataFormat, "buffer" | "hex">

--- a/packages/sdk/src/utils/types.ts
+++ b/packages/sdk/src/utils/types.ts
@@ -20,3 +20,9 @@ export interface EncodeDecodeObjectOptions {
   encode: boolean
   depth?: number
 }
+
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+  }[Keys]
+


### PR DESCRIPTION
This PR adds util methods to decode various formats of PSBT and Tx to finally convert it into a JS native relevant class instance. Following are the supported formats:

- PSBT
  - Buffer
  - Base64
  - Hex
- Transaction
  - Buffer
  - Hex 