### PR TITLE
fix(sdk): allow higher value utxos and return change

### DIFF
--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -121,6 +121,8 @@ export async function generateBuyerPsbt({
   // seller psbt merge
 
   const decodedSellerPsbt = bitcoin.Psbt.fromHex(sellerPsbt, { network: networkObj })
+  const sellPrice = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.outs[0].value - postage
+
   // inputs
   ;(psbt.data.globalMap.unsignedTx as any).tx.ins[2] = (decodedSellerPsbt.data.globalMap.unsignedTx as any).tx.ins[0]
   psbt.data.inputs[2] = decodedSellerPsbt.data.inputs[0]
@@ -166,7 +168,9 @@ export async function generateBuyerPsbt({
   return {
     hex: psbt.toHex(),
     base64: psbt.toBase64(),
-    fee
+    fee,
+    postage,
+    sellPrice
   }
 }
 

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -303,7 +303,7 @@ export class OrdTransaction {
       throw new Error("No commit address found. Please generate a commit address.")
     }
 
-    const outAmount = this.#outs.reduce((acc, cur) => (acc = +cur.value), 0)
+    const outAmount = this.#outs.reduce((acc, cur) => (acc += cur.value), 0)
     const amount = this.postage + this.#feeForWitnessData! + outAmount
 
     const utxos = await OrditApi.fetchSpendables({

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -313,7 +313,7 @@ export class OrdTransaction {
       type: this.#safeMode === "on" ? "spendable" : "all"
     })
 
-    const suitableUTXO = utxos.find((utxo) => utxo.value === amount)
+    const suitableUTXO = utxos.find((utxo) => utxo.value >= amount)
     if (!suitableUTXO) {
       throw new Error("No suitable unspent found for reveal.")
     }


### PR DESCRIPTION
This PR allows higher value UTXO that could potentially be sent by mistake to the commit address. The idea is to return the change if its above the dust value (600 sats), if the difference is less than dust value -- it will be spent as fees.

Also, an issue where instead of addition, parsing was being done has been fixed. Postage, and sell price are now part of the `generateBuyerPsbt` method response.