### PR TITLE
fix(sdk): compare with sats value instead of BTC value

### DIFF
--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -313,7 +313,7 @@ export class OrdTransaction {
       type: this.#safeMode === "on" ? "spendable" : "all"
     })
 
-    const suitableUTXO = utxos.find((utxo) => utxo.value >= amount)
+    const suitableUTXO = utxos.find((utxo) => utxo.sats >= amount)
     if (!suitableUTXO) {
       throw new Error("No suitable unspent found for reveal.")
     }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the incorrect comparison of BTC value w/ sats value. 