### PR TITLE
refactor(sdk): performance improvements

### DIFF
--- a/packages/sdk/src/api/jsonrpc.ts
+++ b/packages/sdk/src/api/jsonrpc.ts
@@ -50,7 +50,7 @@ class JsonRpc {
     if (response.status === 200) {
       const json = await response.json()
       if (json.error) {
-        throw new Error(json.error.message)
+        throw new Error(json.error.data || json.error.message)
       }
       return json.result
     }

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -131,6 +131,7 @@ export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   publicKey: string
   outs?: Outputs
   encodeMetadata?: boolean
+  enableRBF?: boolean
 }
 
 export type CollectionInscription = {
@@ -156,6 +157,7 @@ export type MintFromCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   outs?: Outputs
   traits?: any
   encodeMetadata?: boolean
+  enableRBF?: boolean
 }
 
 type Outputs = Array<{ address: string; value: number }>

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -52,8 +52,12 @@ export async function mintFromCollection(options: MintFromCollectionOptions) {
     throw new Error("Failed to get raw transaction for id: " + colTxId)
   }
 
-  const colMeta = tx.vout[colVOut].inscriptions[0].meta
+  const collection = tx.vout[colVOut].inscriptions[0]
+  if (!collection) {
+    throw new Error("Invalid collection")
+  }
 
+  const colMeta = collection.meta
   let validInscription = false
 
   for (let i = 0; i < colMeta?.insc.length; i++) {
@@ -68,15 +72,6 @@ export async function mintFromCollection(options: MintFromCollectionOptions) {
 
   if (!validInscription) {
     throw new Error("Invalid inscription iid supplied.")
-  }
-
-  const [collection] = await OrditApi.fetchInscriptions({
-    outpoint: options.collectionOutpoint,
-    network: options.network
-  })
-
-  if (!collection) {
-    throw new Error("Invalid collection")
   }
 
   const meta: any = {

--- a/packages/sdk/src/transactions/psbt.ts
+++ b/packages/sdk/src/transactions/psbt.ts
@@ -215,7 +215,7 @@ export type CreatePsbtOptions = {
     address: string
     cardinals: number
   }[]
-  enableRBF: boolean
+  enableRBF?: boolean
   pubKey: string
   network: Network
   safeMode?: OnOffUnion


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR has the following changes:
1. Extended publish collection and mint asset functions to accept `enableRBF` flag
2. Extended `OrdTransaction` class to accept `enableRBF` flag
3. Return detailed error message for clarity on errors returned by RPC
4. Remove extra RPC call and use existing data

