### PR TITLE
refactor(sdk): retrieve signing data for XVerse wallet functions

### DIFF
--- a/packages/sdk/src/browser-wallets/types.ts
+++ b/packages/sdk/src/browser-wallets/types.ts
@@ -1,0 +1,4 @@
+export interface BrowserWalletSignPSBTResponse {
+  hex: string
+  base64: string | null
+}

--- a/packages/sdk/src/browser-wallets/xverse/signatures.ts
+++ b/packages/sdk/src/browser-wallets/xverse/signatures.ts
@@ -3,6 +3,7 @@ import { signMessage as _signMessage, signTransaction } from "sats-connect"
 
 import { Network } from "../../config/types"
 import { InputsToSign } from "../../inscription/types"
+import { BrowserWalletSignPSBTResponse } from "../types"
 import { isXverseInstalled, XverseNetwork } from "./utils"
 
 export async function signPsbt({
@@ -12,7 +13,7 @@ export async function signPsbt({
   finalize = true,
   extractTx = true,
   message = "Sign Transaction"
-}: XverseSignPsbtOptions) {
+}: XverseSignPsbtOptions): Promise<BrowserWalletSignPSBTResponse> {
   if (!psbt || !network || !inputs.length) {
     throw new Error("Invalid options provided.")
   }
@@ -21,7 +22,8 @@ export async function signPsbt({
     throw new Error("xverse not installed.")
   }
 
-  let hex = null
+  let hex: string
+  let base64: string | null = null
   const handleFinish = (response: XverseSignPsbtResponse) => {
     const { psbtBase64 } = response
     if (!psbtBase64) {
@@ -32,6 +34,7 @@ export async function signPsbt({
 
     finalize && signedPsbt.finalizeAllInputs()
     hex = extractTx ? signedPsbt.extractTransaction().toHex() : signedPsbt.toHex()
+    base64 = !extractTx ? signedPsbt.toBase64() : null
   }
 
   const xverseOptions = {
@@ -50,7 +53,7 @@ export async function signPsbt({
 
   await signTransaction(xverseOptions)
 
-  return { hex }
+  return { hex: hex!, base64 }
 }
 
 export async function signMessage(options: XverseSignMessageOptions) {

--- a/packages/sdk/src/config/index.ts
+++ b/packages/sdk/src/config/index.ts
@@ -19,4 +19,6 @@ export const apiConfig = {
   }
 }
 
+// Input from seller PSBT when unwrapped & merged,
+// is placed on the 2nd index in instant-buy-sell flow
 export const INSTANT_BUY_SELLER_INPUT_INDEX = 2

--- a/packages/sdk/src/config/index.ts
+++ b/packages/sdk/src/config/index.ts
@@ -18,3 +18,5 @@ export const apiConfig = {
     }
   }
 }
+
+export const INSTANT_BUY_SELLER_INPUT_INDEX = 2

--- a/packages/sdk/src/inscription/types.ts
+++ b/packages/sdk/src/inscription/types.ts
@@ -40,3 +40,9 @@ export interface Inscription {
   mediaContent: string
   meta?: Record<string, any>
 }
+
+export interface InputsToSign {
+  address: string
+  signingIndexes: number[]
+  sigHash?: number
+}

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -16,6 +16,7 @@ import {
 } from ".."
 import { Network } from "../config/types"
 import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
+import { InputsToSign } from "../inscription/types"
 import { NestedObject } from "../utils/types"
 
 bitcoin.initEccLib(ecc)
@@ -32,6 +33,8 @@ export class OrdTransaction {
   network: Network
   psbt: bitcoin.Psbt | null = null
   ready = false
+  address: string
+  inputsToSign: InputsToSign
   #xKey: string
   #feeForWitnessData: number | null = null
   #commitAddress: string | null = null
@@ -72,13 +75,18 @@ export class OrdTransaction {
     this.#encodeMetadata = encodeMetadata
     this.#enableRBF = enableRBF
 
-    const xKey = getAddressesFromPublicKey(publicKey, network, "p2tr")[0].xkey
+    const { xkey, address } = getAddressesFromPublicKey(publicKey, network, "p2tr")[0]
 
-    if (!xKey) {
+    if (!xkey) {
       throw new Error("Failed to derive xKey from the provided public key.")
     }
 
-    this.#xKey = xKey
+    this.#xKey = xkey
+    this.address = address!
+    this.inputsToSign = {
+      address: this.address,
+      signingIndexes: []
+    }
   }
 
   get outs() {
@@ -127,6 +135,8 @@ export class OrdTransaction {
         }
       ]
     })
+
+    this.inputsToSign.signingIndexes.push(0) // hardcoding because there will always be one input
 
     if (!this.#recovery) {
       psbt.addOutput({

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -205,26 +205,22 @@ export class Ordit {
     let psbtHasBeenSigned = false
 
     for (let i = 0; i < inputsToSign.length; i++) {
-      try {
-        const input = psbt.data.inputs[i]
-        psbtHasBeenSigned = input.finalScriptSig || input.finalScriptWitness ? true : false
+      const input = psbt.data.inputs[inputsToSign[i].index]
+      psbtHasBeenSigned = input.finalScriptSig || input.finalScriptWitness ? true : false
 
-        if (psbtHasBeenSigned) continue
+      if (psbtHasBeenSigned) continue
 
-        if (isTaprootInput(input)) {
-          const tweakedSigner = tweakSigner(this.#keyPair, {
-            network: networkObj
-          })
+      if (isTaprootInput(input)) {
+        const tweakedSigner = tweakSigner(this.#keyPair, {
+          network: networkObj
+        })
 
-          const signer =
-            input.witnessUtxo?.script && input.tapInternalKey && !input.tapLeafScript ? tweakedSigner : this.#keyPair
+        const signer =
+          input.witnessUtxo?.script && input.tapInternalKey && !input.tapLeafScript ? tweakedSigner : this.#keyPair
 
-          psbt.signInput(inputsToSign[i].index, signer, inputsToSign[i].sighashTypes)
-        } else {
-          psbt.signInput(inputsToSign[i].index, this.#keyPair, inputsToSign[i].sighashTypes)
-        }
-      } catch (e) {
-        throw new Error(e.message)
+        psbt.signInput(inputsToSign[i].index, signer, inputsToSign[i].sighashTypes)
+      } else {
+        psbt.signInput(inputsToSign[i].index, this.#keyPair, inputsToSign[i].sighashTypes)
       }
     }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates all relevant ordit-sdk fns that builds a PSBT to return signing data to support XVerse wallet fns. Input indexes to sign w/ corresponding `address`, and an optional `sigHash` will be returned by ordit-sdk fns.