### PR TITLE
fix(sdk): use dynamic witness generated by payments API to calculate fee

### DIFF
--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -97,7 +97,10 @@ export class OrdTransaction {
         totalInputs: 1,
         totalOutputs: 1, // change output
         satsPerByte: this.feeRate,
-        type: "taproot" // hardcoding because recovery is only supported by Taproot txs
+        type: "taproot", // hardcoding because recovery is only supported by Taproot txs
+        additional: {
+          witnessScripts: this.#inscribePayTx.witness
+        }
       })
     }
 
@@ -281,6 +284,16 @@ export class OrdTransaction {
       redeem: redeemScript
     })
 
+    // recovery tx always have 1 input and 1 output
+    const fees = calculateTxFee({
+      totalInputs: 1,
+      totalOutputs: 1,
+      satsPerByte: this.feeRate,
+      type: "taproot", // hardcoding because this process is only supported by Taproot txs
+      additional: { witnessScripts: inscribePayTx.witness }
+    })
+
+    this.#feeForWitnessData = fees
     this.#inscribePayTx = inscribePayTx
     this.#recovery = true
   }

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -222,7 +222,7 @@ export class OrdTransaction {
       totalOutputs: 1,
       satsPerByte: this.feeRate,
       type: "taproot", // hardcoding because this process is only supported by Taproot txs
-      additional: { witnessScripts: [witnessScript] }
+      additional: { witnessScripts: inscribePayTx.witness }
     })
 
     const customOutsAmount = this.#outs.reduce((acc, cur) => {

--- a/packages/sdk/src/transactions/OrdTransaction.ts
+++ b/packages/sdk/src/transactions/OrdTransaction.ts
@@ -284,16 +284,6 @@ export class OrdTransaction {
       redeem: redeemScript
     })
 
-    // recovery tx always have 1 input and 1 output
-    const fees = calculateTxFee({
-      totalInputs: 1,
-      totalOutputs: 1,
-      satsPerByte: this.feeRate,
-      type: "taproot", // hardcoding because this process is only supported by Taproot txs
-      additional: { witnessScripts: inscribePayTx.witness }
-    })
-
-    this.#feeForWitnessData = fees
     this.#inscribePayTx = inscribePayTx
     this.#recovery = true
   }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the fee issue for Taproot txs specifically in the inscription, and funds recovery flow. The root cause of the issue is that during fee calculation, the raw witness script was used to calculate the fee whereas the correct way to do that is to send the raw witness to payments API of bitcoinjs-lib `bitcoin.payments.[p2tr|p2sh|etc]` and access the `witness` property of the response.

The accuracy is not 100% but still better than the previous 8% miscalculation. Now, its off by 0.33%.

Custom fee rate: 3 sats/vByte
Prev implementation: 2.76; [inscription tx](https://mempool.space/testnet/tx/edaf7356b1a0ec9b7672bc74a86635c5a095e9a9911f0f6f1450848f0a52b429)
Now: 2.99; [inscription tx](https://mempool.space/testnet/tx/99a5e2ecd3a550245b03d7acf91003e6563ee49cdd0e07e7a738ce66efff504f)
Now: 2.99; [recovery tx](https://mempool.space/testnet/tx/e81ce4bab42809d914a0a6afac7dda3aa8d584b3a0ae45b02638e61eee9ba265)

