### PR TITLE
feature(instant-buy): Support BiAddress system (Xverse)

### DIFF
--- a/examples/node/instant-buy.js
+++ b/examples/node/instant-buy.js
@@ -40,8 +40,8 @@ async function createBuyOrder({ sellerPSBT }) {
 
     const { hex: buyerPSBT } = await Ordit.instantBuy.generateBuyerPsbt({
         sellerPsbt: sellerPSBT,
-        publicKey: buyerWallet.publicKey,
-        pubKeyType: buyerWallet.selectedAddressType,
+        publicKey: { payments: buyerWallet.publicKey, inscriptions: buyerWallet.publicKey },
+        pubKeyType: { payments: buyerWallet.selectedAddressType, inscriptions: buyerWallet.selectedAddressType },
         feeRate: 10, // set correct rate to prevent tx from getting stuck in mempool
         network: 'testnet',
         inscriptionOutPoint: '0f3891f61b944c31fb48b0d9e770dc9e66a4b49097027be53b078be67aca72d4:0'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Xverse uses two address: taproot & nested-segwit: one is for payments, and the other is for inscriptions.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors 
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
