### PR TITLE
refactor(sdk): add optional destination address arg to receive inscription

### DIFF
--- a/packages/sdk/src/inscription/instant-buy.ts
+++ b/packages/sdk/src/inscription/instant-buy.ts
@@ -51,7 +51,8 @@ export async function generateBuyerPsbt({
   feeRate = 10,
   network = "testnet",
   sellerPsbt,
-  inscriptionOutPoint
+  inscriptionOutPoint,
+  inscriptionDestinationAddress
 }: GenerateBuyerInstantBuyPsbtOptions) {
   const networkObj = getNetwork(network)
   const format = addressNameToType[pubKeyType]
@@ -114,7 +115,7 @@ export async function generateBuyerPsbt({
 
   // Add ordinal output
   psbt.addOutput({
-    address: address.address!,
+    address: inscriptionDestinationAddress || address.address!,
     value: postage
   })
 
@@ -310,6 +311,7 @@ export interface GenerateBuyerInstantBuyPsbtOptions {
   feeRate?: number
   inscriptionOutPoint: string
   sellerPsbt: string
+  inscriptionDestinationAddress?: string
 }
 
 export interface GenerateRefundableUTXOsOptions {


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds an optional arg option `inscriptionDestinationAddress` to `generateBuyerPsbt` fn. This arg option can be used to receive inscriptions on an address other the buyer address. 

Wallets like Xverse that have distinct addresses w/ strict purpose for payments and storing inscriptions can also be supported w/ this change. 