### PR TITLE
fix(sdk-xverse): finalize specific inputs when passed explicitly

### DIFF
--- a/packages/sdk/src/browser-wallets/xverse/signatures.ts
+++ b/packages/sdk/src/browser-wallets/xverse/signatures.ts
@@ -32,7 +32,18 @@ export async function signPsbt({
 
     const signedPsbt = Psbt.fromBase64(psbtBase64)
 
-    finalize && signedPsbt.finalizeAllInputs()
+    if (finalize) {
+      if (!inputs.length) {
+        signedPsbt.finalizeAllInputs()
+      } else {
+        inputs.forEach((input) => {
+          input.signingIndexes.forEach((index) => {
+            signedPsbt.finalizeInput(index)
+          })
+        })
+      }
+    }
+
     hex = extractTx ? signedPsbt.extractTransaction().toHex() : signedPsbt.toHex()
     base64 = !extractTx ? signedPsbt.toBase64() : null
   }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the Xverse signer wrapper by finalizing only the inputs explicitly passed wrt. indexes passed. In the instant-buy-sell flow inputs belonging to multi parties are merged into a single PSBT and the party broadcasting the final tx is supposed to ensure all inputs are finalized. 

Changes in this PR only finalizes the inputs that are explicitly asked to finalize instead of the current implementation that finalizes all inputs.


