### PR TITLE
feat(sdk)!: introduce royalty payments in instant-trade flow

### DIFF
--- a/examples/node/collections.js
+++ b/examples/node/collections.js
@@ -17,19 +17,20 @@ const publisherWallet = new Ordit({
 
 // set default address types for both wallets
 userWallet.setDefaultAddress("taproot");
-publisherWallet.setDefaultAddress("nested-segwit");
+publisherWallet.setDefaultAddress("taproot");
 
 async function publish() {
   const getPublisherLegacyAddress = () => {
     publisherWallet.setDefaultAddress("legacy")
     const legacyAddress = publisherWallet.selectedAddress
-    publisherWallet.setDefaultAddress("nested-segwit") // switch back to default
+    publisherWallet.setDefaultAddress("taproot") // switch back to default
 
     return legacyAddress
   }
 
   //publish
   const transaction = await publishCollection({
+    address: publisherWallet.selectedAddress,
     network,
     feeRate: 2,
     title: "Collection Name",
@@ -87,6 +88,7 @@ async function mint() {
   
   // publish
   const transaction = await mintFromCollection({
+    address: userWallet.selectedAddress,
     network,
     collectionOutpoint: collectionId,
     inscriptionIid: "el-01",

--- a/examples/node/collections.js
+++ b/examples/node/collections.js
@@ -40,17 +40,16 @@ async function publish() {
       email: "your-email@example.com",
       name: "Your Name"
     },
+    royalty: {
+      address: publisherWallet.selectedAddress,
+      pct: 0.05
+    },
     publishers: [getPublisherLegacyAddress()],
     inscriptions: [
       {
         iid: "el-01",
         lim: 10,
         sri: "sha256-Ujac9y464/qlFmtfLDxORaUtIDH8wrHgv8L9bpPeb28="
-      },
-      {
-        iid: "el-02",
-        lim: 2,
-        sri: "sha256-zjQXDuk++5sICrObmfWqAM5EibidXd2emZoUcU2l5Pg="
       }
     ],
     url: "https://example.com",
@@ -58,7 +57,7 @@ async function publish() {
     destination: publisherWallet.selectedAddress,
     changeAddress: publisherWallet.selectedAddress,
     postage: 1000,
-    mediaContent: 'Collection Name', // this will be inscribed on-chain as primary content
+    mediaContent: '5% Royalty Collection', // this will be inscribed on-chain as primary content
     mediaType: "text/plain"
   });
 

--- a/packages/sdk/src/fee/FeeEstimator.ts
+++ b/packages/sdk/src/fee/FeeEstimator.ts
@@ -6,11 +6,11 @@ import { MAXIMUM_FEE } from "../constants"
 import { FeeEstimatorOptions } from "./types"
 
 export default class FeeEstimator {
-  feeRate: number
-  network: Network
-  psbt!: Psbt
-  witness?: Buffer[] = []
-  fee = 0
+  protected feeRate: number
+  protected network: Network
+  protected psbt: Psbt
+  protected witness?: Buffer[] = []
+  protected fee = 0
 
   private virtualSize = 0
   private weight = 0

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -17,16 +17,18 @@ export async function publishCollection({
   }
 
   // 0 = 0%, 10 = 1000%
-  if (royalty.pct < 0 || royalty.pct > 10) {
+  if (royalty && (royalty.pct < 0 || royalty.pct > 10)) {
     throw new Error("Invalid royalty %")
   }
 
-  royalty.pct = +new Intl.NumberFormat("en", {
-    maximumFractionDigits: 5,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    roundingMode: "trunc"
-  }).format(royalty.pct)
+  if (royalty) {
+    royalty.pct = +new Intl.NumberFormat("en", {
+      maximumFractionDigits: 5,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      roundingMode: "trunc"
+    }).format(royalty.pct)
+  }
 
   const collectionMeta = {
     p: "vord", // protocol
@@ -141,7 +143,7 @@ export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
     email?: string
     address: string
   }
-  royalty: {
+  royalty?: {
     address: string
     pct: number
   }

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -16,12 +16,12 @@ export async function publishCollection({
     throw new Error("Invalid inscriptions supplied.")
   }
 
-  // 0 = 0%, 10 = 1000%
-  if (royalty && (royalty.pct < 0 || royalty.pct > 10)) {
-    throw new Error("Invalid royalty %")
-  }
-
   if (royalty) {
+    // 0 = 0%, 10 = 1000%
+    if (isNaN(royalty.pct) || royalty.pct < 0 || royalty.pct > 10) {
+      throw new Error("Invalid royalty %")
+    }
+
     royalty.pct = +new Intl.NumberFormat("en", {
       maximumFractionDigits: 5,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -7,6 +7,7 @@ export async function publishCollection({
   url,
   slug,
   creator,
+  royalty,
   publishers,
   inscriptions,
   ...options
@@ -15,15 +16,28 @@ export async function publishCollection({
     throw new Error("Invalid inscriptions supplied.")
   }
 
+  // 0 = 0%, 10 = 1000%
+  if (royalty.pct < 0 || royalty.pct > 10) {
+    throw new Error("Invalid royalty %")
+  }
+
+  royalty.pct = +new Intl.NumberFormat("en", {
+    maximumFractionDigits: 2,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    roundingMode: "trunc"
+  }).format(royalty.pct)
+
   const collectionMeta = {
     p: "vord", // protocol
     v: 1, // version
     ty: "col",
-    title: title,
+    title,
     desc: description,
-    url: url,
-    slug: slug,
-    creator: creator,
+    url,
+    slug,
+    creator,
+    royalty,
     publ: publishers,
     insc: inscriptions
   }
@@ -126,6 +140,10 @@ export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
     name?: string
     email?: string
     address: string
+  }
+  royalty: {
+    address: string
+    pct: number
   }
   network: Network
   publicKey: string

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -126,6 +126,7 @@ function validateInscriptions(inscriptions: CollectionInscription[] = []) {
 }
 
 export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
+  address: string
   feeRate: number
   postage: number
   mediaType: string
@@ -161,6 +162,7 @@ export type CollectionInscription = {
 }
 
 export type MintFromCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
+  address: string
   feeRate: number
   postage: number
   mediaType: string

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -22,7 +22,7 @@ export async function publishCollection({
   }
 
   royalty.pct = +new Intl.NumberFormat("en", {
-    maximumFractionDigits: 2,
+    maximumFractionDigits: 5,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     roundingMode: "trunc"

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -23,7 +23,7 @@ export async function publishCollection({
     }
 
     royalty.pct = +new Intl.NumberFormat("en", {
-      maximumFractionDigits: 5,
+      maximumFractionDigits: 8,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       roundingMode: "trunc"

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -149,7 +149,7 @@ export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   }
   network: Network
   publicKey: string
-  outs?: Outputs
+  outputs?: Outputs
   encodeMetadata?: boolean
   enableRBF?: boolean
 }
@@ -174,7 +174,7 @@ export type MintFromCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   signature: string
   network: Network
   publicKey: string
-  outs?: Outputs
+  outputs?: Outputs
   traits?: any
   encodeMetadata?: boolean
   enableRBF?: boolean

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -10,6 +10,7 @@ export default class InstantTradeBuilder extends PSBTBuilder {
   protected inscriptionOutpoint?: string
   protected price = 0
   protected postage = 0
+  protected royalty = 0
 
   constructor({ address, network, publicKey, inscriptionOutpoint }: InstantTradeBuilderArgOptions) {
     super({
@@ -28,6 +29,10 @@ export default class InstantTradeBuilder extends PSBTBuilder {
   setPrice(value: number) {
     this.validatePrice(value)
     this.price = parseInt(value.toString())
+  }
+
+  setRoyalty(value: number) {
+    this.royalty = value
   }
 
   protected async verifyAndFindInscriptionUTXO(address?: string) {

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -3,7 +3,7 @@ import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
 import { PSBTBuilder, PSBTBuilderOptions } from "../transactions/PSBTBuilder"
 
 export interface InstantTradeBuilderArgOptions
-  extends Pick<PSBTBuilderOptions, "publicKey" | "network" | "address" | "autoAdjustment"> {
+  extends Pick<PSBTBuilderOptions, "publicKey" | "network" | "address" | "autoAdjustment" | "feeRate"> {
   inscriptionOutpoint?: string
 }
 

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -2,7 +2,8 @@ import { OrditApi } from ".."
 import { MINIMUM_AMOUNT_IN_SATS } from "../constants"
 import { PSBTBuilder, PSBTBuilderOptions } from "../transactions/PSBTBuilder"
 
-export interface InstantTradeBuilderArgOptions extends Pick<PSBTBuilderOptions, "publicKey" | "network" | "address"> {
+export interface InstantTradeBuilderArgOptions
+  extends Pick<PSBTBuilderOptions, "publicKey" | "network" | "address" | "autoAdjustment"> {
   inscriptionOutpoint?: string
 }
 
@@ -12,13 +13,14 @@ export default class InstantTradeBuilder extends PSBTBuilder {
   protected postage = 0
   protected royalty = 0
 
-  constructor({ address, network, publicKey, inscriptionOutpoint }: InstantTradeBuilderArgOptions) {
+  constructor({ address, network, publicKey, inscriptionOutpoint, autoAdjustment }: InstantTradeBuilderArgOptions) {
     super({
       address,
       feeRate: 0,
       network,
       publicKey,
       outputs: [],
+      autoAdjustment,
       instantTradeMode: true
     })
 

--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -98,17 +98,17 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
         sats: this.sellerPSBT.data.inputs[0].witnessUtxo?.value,
         injectionIndex: INSTANT_BUY_SELLER_INPUT_INDEX
       }
-    ] as unknown as InjectableInput[]
+    ] as InjectableInput[]
 
-    //outputs
-    this.injectableOutputs = [
-      {
-        standardOutput: this.sellerPSBT.data.outputs[0],
-        txOutput: (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[0],
-        sats: (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[0].value,
-        injectionIndex: INSTANT_BUY_SELLER_INPUT_INDEX
-      }
-    ] as InjectableOutput[]
+    // outputs
+    this.injectableOutputs = this.sellerPSBT.data.outputs.map((standardOutput, index) => {
+      return {
+        standardOutput,
+        txOutput: (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[index],
+        sats: (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[index].value,
+        injectionIndex: INSTANT_BUY_SELLER_INPUT_INDEX + index
+      } as InjectableOutput
+    })
   }
 
   private async findUTXOs() {

--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -68,6 +68,11 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     this.setPrice((this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[0].value - this.postage)
   }
 
+  private decodeRoyalty() {
+    const royaltyOutput = (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[1]
+    royaltyOutput && this.setRoyalty(royaltyOutput.value)
+  }
+
   private bindRefundableOutput() {
     this.outputs = [
       {
@@ -155,6 +160,7 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     }
 
     this.decodePrice()
+    this.decodeRoyalty()
     this.bindRefundableOutput()
     this.bindInscriptionOutput()
     this.mergePSBTs()

--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -15,7 +15,6 @@ import { Output } from "../transactions/types"
 import InstantTradeBuilder, { InstantTradeBuilderArgOptions } from "./InstantTradeBuilder"
 
 interface InstantTradeBuyerTxBuilderArgOptions extends InstantTradeBuilderArgOptions {
-  feeRate: number
   sellerPSBT: string
   receiveAddress?: string
 }
@@ -36,10 +35,10 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     super({
       address,
       network,
-      publicKey
+      publicKey,
+      feeRate
     })
 
-    this.feeRate = feeRate
     this.receiveAddress = receiveAddress
     this.decodeSellerPSBT(sellerPSBT)
   }

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -65,7 +65,7 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
     }
 
     const collection = await OrditApi.fetchInscription({
-      id: this.utxo.inscriptions[0].meta.col,
+      id: `${this.utxo.inscriptions[0].meta.col}i0`,
       network: this.network
     })
     const royalty = collection.meta?.royalty

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -25,11 +25,11 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
       network,
       publicKey,
       inscriptionOutpoint,
-      autoAdjustment: false // Prevents PSBTBuilder from adding additional input and change output
+      autoAdjustment: false, // Prevents PSBTBuilder from adding additional input and change output
+      feeRate: 0 // seller in instant-trade does not pay network fee
     })
 
     this.receiveAddress = receiveAddress
-    this.feeRate = 0 // seller in instant-trade does not pay network fee
   }
 
   private async generatSellerInputs() {

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -51,7 +51,7 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
     const royalty = await this.calculateRoyalty()
     this.outputs = [{ address: this.receiveAddress || this.address, value: this.price + this.postage }]
 
-    if (royalty) {
+    if (royalty && royalty.amount >= MINIMUM_AMOUNT_IN_SATS) {
       this.outputs.push({
         address: royalty.address, // creator address
         value: royalty.amount // royalty in sats to be paid to original creator
@@ -76,7 +76,7 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
 
     return {
       address: royalty.address as string,
-      amount: amount >= MINIMUM_AMOUNT_IN_SATS ? amount : MINIMUM_AMOUNT_IN_SATS
+      amount: amount >= MINIMUM_AMOUNT_IN_SATS ? amount : 0
     }
   }
 

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -24,7 +24,8 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
       address,
       network,
       publicKey,
-      inscriptionOutpoint
+      inscriptionOutpoint,
+      autoAdjustment: false // Prevents PSBTBuilder from adding additional input and change output
     })
 
     this.receiveAddress = receiveAddress
@@ -86,7 +87,7 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
 
     this.utxo = await this.verifyAndFindInscriptionUTXO()
     await this.generatSellerInputs()
-    this.generateSellerOutputs()
+    await this.generateSellerOutputs()
 
     await this.prepare()
   }

--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -70,7 +70,7 @@ export class Inscriber extends PSBTBuilder {
       network,
       publicKey,
       outputs,
-      inscriberMode: true
+      autoAdjustment: false
     })
     if (!publicKey || !changeAddress || !destination || !mediaContent) {
       throw new Error("Invalid options provided")

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -280,6 +280,10 @@ export class PSBTBuilder extends FeeEstimator {
     }
   }
 
+  private getRetrievedUTXOsValue() {
+    return this.utxos.reduce((acc, utxo) => (acc += utxo.sats), 0)
+  }
+
   private getReservedUTXOs() {
     return this.utxos.map((utxo) => generateTxUniqueIdentifier(utxo.txid, utxo.n))
   }
@@ -288,6 +292,8 @@ export class PSBTBuilder extends FeeEstimator {
     if (!this.autoAdjustment && !address) return
 
     amount = amount && amount > 0 ? amount : this.changeAmount < 0 ? this.changeAmount * -1 : this.outputAmount
+
+    if (this.getRetrievedUTXOsValue() > amount) return
 
     const utxos = await OrditApi.fetchSpendables({
       address: address || this.address,


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR introduces a new feature called **Royalty** as defined in [OIP-6](https://www.oips.io/oip-06-ordinals-royalty-standard). This new feature would enable new collections created by artists/creators to receive a royalty payment on each trade. Participating marketplaces should follow OIP-6 as the guideline to enable royalty payments on their platform.

**Note**: Royalty is an optional feature and creators can opt-out at the time of collection creation.

Creators can choose royalty in % as low as 0.001% all the way up to 1000%. On every trade tx, the royalty payment would be would be calculated wrt. to the sell price. 

```
E.g., 
sell price = 200000 sats
royalty set by creator = 5%
royalty to be paid to creator = 10000 sats
```

In case the calculated royalty in sats is lower than dust or 600 sats, the creator would not be paid any royalty.

❗Breaking changes
- added `address` arg option (required) to `publishCollection`, `mintCollection`, and `Inscriber` class
- renamed `outs` to `outputs` in `publishCollection`and `mintCollection`
- renamed `inscriberMode` to `autoAdjustment`
- access `inputsToSign` as a member on any class derived from `PSBTBuilder` or directly on `PSBTBuilder` itself. Required to call `PSBTBuilder.prepare()` before accessing it