### PR TITLE
feat(sdk): add sats and ownership check

### DIFF
--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -34,7 +34,7 @@ export class OrditApi {
     network = "testnet",
     type = "spendable",
     rarity = ["common"],
-    decodeMetadata = true,
+    decodeMetadata = false,
     sort = "desc"
   }: FetchUnspentUTXOsOptions): Promise<FetchUnspentUTXOsResponse> {
     if (!address) {
@@ -88,7 +88,7 @@ export class OrditApi {
     ordinals = true,
     hex = false,
     witness = true,
-    decodeMetadata = true
+    decodeMetadata = false
   }: FetchTxOptions): Promise<FetchTxResponse> {
     if (!txId) {
       throw new Error("Invalid txId")
@@ -118,7 +118,7 @@ export class OrditApi {
     }
   }
 
-  static async fetchInscriptions({ outpoint, network = "testnet", decodeMetadata = true }: GetInscriptionsOptions) {
+  static async fetchInscriptions({ outpoint, network = "testnet", decodeMetadata = false }: GetInscriptionsOptions) {
     if (!outpoint) {
       throw new Error("Invalid options provided.")
     }
@@ -139,7 +139,7 @@ export class OrditApi {
     return inscriptions
   }
 
-  static async fetchInscription({ id, network = "testnet", decodeMetadata = true }: FetchInscriptionOptions) {
+  static async fetchInscription({ id, network = "testnet", decodeMetadata = false }: FetchInscriptionOptions) {
     if (!id) {
       throw new Error("Invalid options provided.")
     }

--- a/packages/sdk/src/fee/FeeEstimator.ts
+++ b/packages/sdk/src/fee/FeeEstimator.ts
@@ -138,7 +138,7 @@ export default class FeeEstimator {
         return { input: 64, output: 32, txHeader: 10, witness: 105 }
 
       case "legacy":
-        return { input: 149, output: 34, txHeader: 10, witness: 0 }
+        return { input: 148, output: 34, txHeader: 10, witness: 0 }
 
       default:
         throw new Error("Invalid type")

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -71,7 +71,7 @@ export default class InstantTradeBuilder extends PSBTBuilder {
       throw new Error("Inscription not found")
     }
 
-    const utxo = await this.datasource.getInscriptionUTXO(this.inscription.outpoint)
+    const utxo = await this.datasource.getInscriptionUTXO(this.inscription.genesis)
     if (!utxo) {
       throw new Error(`Unable to find UTXO: ${this.inscription.outpoint}`)
     }

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -80,12 +80,19 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
     }
   }
 
+  private validateOwnership() {
+    if (this.inscription?.owner !== this.address) {
+      throw new Error(`Inscription does not belong to the address: ${this.address}`)
+    }
+  }
+
   async build() {
     if (isNaN(this.price) || this.price < MINIMUM_AMOUNT_IN_SATS) {
       throw new Error("Invalid price")
     }
 
     this.utxo = await this.verifyAndFindInscriptionUTXO()
+    this.validateOwnership()
     await this.generatSellerInputs()
     await this.generateSellerOutputs()
 

--- a/packages/sdk/src/modules/JsonRpcDatasource.ts
+++ b/packages/sdk/src/modules/JsonRpcDatasource.ts
@@ -92,7 +92,7 @@ export default class JsonRpcDatasource extends BaseDatasource {
     ordinals = true,
     hex = false,
     witness = true,
-    decodeMetadata = true
+    decodeMetadata = false
   }: FetchTxOptions) {
     if (!txId) {
       throw new Error("Invalid request")
@@ -128,7 +128,7 @@ export default class JsonRpcDatasource extends BaseDatasource {
     address, // TODO rename interface
     type = "spendable",
     rarity = ["common"],
-    decodeMetadata = true,
+    decodeMetadata = false,
     sort = "desc",
     limit = 50,
     next = null

--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -14,7 +14,7 @@ import {
 import { Network } from "../config/types"
 import { NestedObject } from "../utils/types"
 import { PSBTBuilder } from "./PSBTBuilder"
-import { UTXOLimited } from "./types"
+import { SkipStrictSatsCheckOptions, UTXOLimited } from "./types"
 
 bitcoin.initEccLib(ecc)
 
@@ -241,12 +241,12 @@ export class Inscriber extends PSBTBuilder {
     await this.calculateNetworkFeeUsingPreviewMode()
   }
 
-  async isReady(skipStrictSatsCheck = false) {
+  async isReady({ skipStrictSatsCheck, customAmount }: SkipStrictSatsCheckOptions = {}) {
     this.isBuilt()
 
     if (!this.ready) {
       try {
-        await this.fetchAndSelectSuitableUnspent(skipStrictSatsCheck)
+        await this.fetchAndSelectSuitableUnspent({ skipStrictSatsCheck, customAmount })
       } catch (error) {
         return false
       }
@@ -255,12 +255,16 @@ export class Inscriber extends PSBTBuilder {
     return this.ready
   }
 
-  async fetchAndSelectSuitableUnspent(skipStrictSatsCheck = false) {
+  async fetchAndSelectSuitableUnspent({ skipStrictSatsCheck, customAmount }: SkipStrictSatsCheckOptions = {}) {
     this.restrictUsageInPreviewMode()
     this.isBuilt()
 
-    const amount = this.recovery ? this.outputAmount - this.fee : this.outputAmount + this.fee
-    const [utxo] = await this.retrieveSelectedUTXOs(this.commitAddress!, amount, skipStrictSatsCheck)
+    const amount = this.recovery
+      ? this.outputAmount - this.fee
+      : skipStrictSatsCheck && customAmount && !isNaN(customAmount)
+      ? customAmount
+      : this.outputAmount + this.fee
+    const [utxo] = await this.retrieveSelectedUTXOs(this.commitAddress!, amount)
     this.suitableUnspent = utxo
     this.ready = true
 

--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -241,12 +241,12 @@ export class Inscriber extends PSBTBuilder {
     await this.calculateNetworkFeeUsingPreviewMode()
   }
 
-  async isReady() {
+  async isReady(skipStrictSatsCheck = false) {
     this.isBuilt()
 
     if (!this.ready) {
       try {
-        await this.fetchAndSelectSuitableUnspent()
+        await this.fetchAndSelectSuitableUnspent(skipStrictSatsCheck)
       } catch (error) {
         return false
       }
@@ -255,12 +255,12 @@ export class Inscriber extends PSBTBuilder {
     return this.ready
   }
 
-  async fetchAndSelectSuitableUnspent() {
+  async fetchAndSelectSuitableUnspent(skipStrictSatsCheck = false) {
     this.restrictUsageInPreviewMode()
     this.isBuilt()
 
     const amount = this.recovery ? this.outputAmount - this.fee : this.outputAmount + this.fee
-    const [utxo] = await this.retrieveSelectedUTXOs(this.commitAddress!, amount)
+    const [utxo] = await this.retrieveSelectedUTXOs(this.commitAddress!, amount, skipStrictSatsCheck)
     this.suitableUnspent = utxo
     this.ready = true
 

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -327,11 +327,10 @@ export class PSBTBuilder extends FeeEstimator {
     this.utxos.push(...utxos)
   }
 
-  protected async retrieveSelectedUTXOs(address: string, amount: number, skipStrictSatsCheck = false) {
+  protected async retrieveSelectedUTXOs(address: string, amount: number) {
     await this.retrieveUTXOs(address, amount)
-    const selectedUTXOs = this.utxos.find(
-      (utxo) => skipStrictSatsCheck || (!skipStrictSatsCheck && utxo.sats >= amount)
-    )
+    const selectedUTXOs = this.utxos.find((utxo) => utxo.sats >= amount)
+
     this.utxos = selectedUTXOs ? [selectedUTXOs] : []
 
     return this.utxos

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -326,9 +326,11 @@ export class PSBTBuilder extends FeeEstimator {
     this.utxos.push(...utxos)
   }
 
-  protected async retrieveSelectedUTXOs(address: string, amount: number) {
+  protected async retrieveSelectedUTXOs(address: string, amount: number, skipStrictSatsCheck = false) {
     await this.retrieveUTXOs(address, amount)
-    const selectedUTXOs = this.utxos.find((utxo) => utxo.sats >= amount)
+    const selectedUTXOs = this.utxos.find(
+      (utxo) => skipStrictSatsCheck || (!skipStrictSatsCheck && utxo.sats >= amount)
+    )
     this.utxos = selectedUTXOs ? [selectedUTXOs] : []
 
     return this.utxos

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -311,13 +311,14 @@ export class PSBTBuilder extends FeeEstimator {
   private async retrieveUTXOs(address?: string, amount?: number) {
     if (!this.autoAdjustment && !address) return
 
-    amount = amount && amount > 0 ? amount : this.changeAmount < 0 ? this.changeAmount * -1 : this.outputAmount
+    const amountToRequest =
+      amount && amount > 0 ? amount : this.changeAmount < 0 ? this.changeAmount * -1 : this.outputAmount
 
-    if (this.getRetrievedUTXOsValue() > amount) return
+    if (amount && this.getRetrievedUTXOsValue() > amount) return
 
     const utxos = await this.datasource.getSpendables({
       address: address || this.address,
-      value: convertSatoshisToBTC(amount),
+      value: convertSatoshisToBTC(amountToRequest),
       filter: this.getReservedUTXOs()
     })
 

--- a/packages/sdk/src/transactions/types.ts
+++ b/packages/sdk/src/transactions/types.ts
@@ -76,3 +76,8 @@ export interface Output {
   address: string
   value: number
 }
+
+export interface SkipStrictSatsCheckOptions {
+  skipStrictSatsCheck?: boolean
+  customAmount?: number
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds validation to check ownership of the inscription in the seller flow. Also, the flag to skip strict sats introduced in #65 has been restored. 

A few fixes have also been included in the PR. Check the commits/changes to learn more.