### PR TITLE
fix(sdk): create outputs for minimum amount in utxo splitter

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -11,7 +11,8 @@
     "create-psbt": "node create-psbt",
     "instant-buy": "node instant-buy",
     "publish-collection": "node collections",
-    "build-psbt": "node build-psbt"
+    "build-psbt": "node build-psbt",
+    "split-utxo": "node split-utxo"
   },
   "author": "",
   "license": "ISC",

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -66,7 +66,8 @@ export default class InstantTradeBuilder extends PSBTBuilder {
       throw new Error("set inscription outpoint to the class")
     }
 
-    this.inscription = await this.datasource.getInscription(this.inscriptionOutpoint)
+    const inscriptions = await this.datasource.getInscriptions({ outpoint: this.inscriptionOutpoint })
+    this.inscription = inscriptions.find((inscription) => inscription.outpoint === this.inscriptionOutpoint)
     if (!this.inscription) {
       throw new Error("Inscription not found")
     }

--- a/packages/sdk/src/utxos/UTXOManager.ts
+++ b/packages/sdk/src/utxos/UTXOManager.ts
@@ -44,7 +44,7 @@ export default class UTXOManager extends PSBTBuilder {
 
       this.outputs.push({
         address: destinationAddress || this.address,
-        value: amount
+        value: MINIMUM_AMOUNT_IN_SATS
       })
     }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the issue where the UTXO splitter primarily used in the instant-trade flow created incorrect outputs. With the changes in this PR, the splitter fn would now create 2 outputs worth the minimum amount (600 sats).

Also, a fix to find all inscriptions to later find by outpoint has been added in this PR.