### PR TITLE
fix(sdk): send inscription to destination address & recovered funds to change address

### DIFF
--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -48,7 +48,7 @@ export async function publishCollection({
 }
 
 export async function mintFromCollection(options: MintFromCollectionOptions) {
-  if (!options.collectionOutpoint || !options.inscriptionIid || !options.destination) {
+  if (!options.collectionOutpoint || !options.inscriptionIid || !options.destinationAddress) {
     throw new Error("Invalid options supplied.")
   }
 
@@ -126,7 +126,7 @@ export type PublishCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   postage: number
   mediaType: string
   mediaContent: string
-  destination: string
+  destinationAddress: string
   changeAddress: string
   title: string
   description: string
@@ -162,7 +162,7 @@ export type MintFromCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   postage: number
   mediaType: string
   mediaContent: string
-  destination: string
+  destinationAddress: string
   changeAddress: string
   collectionOutpoint: string
   inscriptionIid: string

--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -26,6 +26,7 @@ export class Inscriber extends PSBTBuilder {
 
   private ready = false
   private commitAddress: string | null = null
+  private destinationAddress: string
   private payment: bitcoin.payments.Payment | null = null
   private suitableUnspent: UTXOLimited | null = null
   private recovery = false
@@ -43,6 +44,7 @@ export class Inscriber extends PSBTBuilder {
     network,
     address,
     changeAddress,
+    destinationAddress,
     publicKey,
     feeRate,
     postage,
@@ -66,6 +68,7 @@ export class Inscriber extends PSBTBuilder {
       throw new Error("Invalid options provided")
     }
 
+    this.destinationAddress = destinationAddress
     this.mediaType = mediaType
     this.mediaContent = mediaContent
     this.meta = meta
@@ -117,14 +120,14 @@ export class Inscriber extends PSBTBuilder {
 
     if (!this.recovery) {
       this.outputs.push({
-        address: this.address,
+        address: this.destinationAddress || this.address,
         value: this.postage
       })
     }
 
     if (this.recovery) {
       this.outputs.push({
-        address: this.address,
+        address: this.changeAddress || this.address,
         value: this.suitableUnspent.sats - this.fee
       })
     }
@@ -285,12 +288,12 @@ export class OrdTransaction extends Inscriber {
 export type InscriberArgOptions = Pick<GetWalletOptions, "safeMode"> & {
   network: Network
   address: string
+  destinationAddress: string
   publicKey: string
   feeRate: number
   postage: number
   mediaType: string
   mediaContent: string
-  destination: string
   changeAddress: string
   meta?: NestedObject
   outputs?: Outputs


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR includes the change that will send the inscription to the destination address. In the funds recovery flow, the recovered funds would be sent to the change address. 

In the event where destination address or change address is missing in both the flows, the wallet/address that has initiated the request will receive the inscription, and recovered funds, respectively.