### PR TITLE
fix(sdk): update output order to ensure inscription is on 0th index

### DIFF
--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -119,10 +119,12 @@ export class Inscriber extends PSBTBuilder {
     ]
 
     if (!this.recovery) {
-      this.outputs.push({
-        address: this.destinationAddress || this.address,
-        value: this.postage
-      })
+      this.outputs = [
+        {
+          address: this.destinationAddress || this.address,
+          value: this.postage
+        }
+      ].concat(this.outputs)
     }
 
     if (this.recovery) {
@@ -195,7 +197,7 @@ export class Inscriber extends PSBTBuilder {
       this.initPSBT()
       this.suitableUnspent = null
       this.ready = false
-      this.outputs.pop()
+      this.outputs.shift()
       this.previewMode = false
     }
   }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR includes changes that ensures the outputs are ordered in such a way that the inscription output is always on the 0th index (first output) followed by additional outputs and change output.

