### PR TITLE
feat(sdk): add sigHash to inputsToSign getter

### DIFF
--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-extra-semi */
-import { networks, Psbt } from "bitcoinjs-lib"
+import { networks, Psbt, Transaction } from "bitcoinjs-lib"
 import reverseBuffer from "buffer-reverse"
 
 import {
@@ -133,10 +133,15 @@ export class PSBTBuilder extends FeeEstimator {
   }
 
   get inputsToSign() {
+    const instantTradeSellerFlow = this.instantTradeMode && !this.autoAdjustment
     return this.psbt.txInputs.reduce(
       (acc, _, index) => {
         if (!this.instantTradeMode || (this.instantTradeMode && index !== INSTANT_BUY_SELLER_INPUT_INDEX)) {
           acc.signingIndexes = acc.signingIndexes.concat(index)
+        }
+
+        if (instantTradeSellerFlow) {
+          acc.sigHash = Transaction.SIGHASH_SINGLE | Transaction.SIGHASH_ANYONECANPAY
         }
 
         return acc


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds `sigHash` to `inputsToSign` getter on `PSBTBuilder` class. `sigHash` has to be passed explicitly to XVerse signer despite binding it to the input.
