### PR TITLE
fix(sdk): allow PSBTBuilder to fetch more UTXOs as needed

### DIFF
--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -126,7 +126,7 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     return utxos.slice(0, 2)
   }
 
-  async isEligible() {
+  private async isEligible() {
     if (!this.inscriptionOutpoint) {
       throw new Error("decode seller PSBT to check eligiblity")
     }

--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -123,7 +123,7 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     }
 
     // bind minimum utxos. PSBTBuilder will add more if needed
-    return utxos.slice(0, 3)
+    return utxos.slice(0, 2)
   }
 
   async isEligible() {
@@ -142,24 +142,19 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
     this.postage = inscriptionUTXO.sats
 
     const sortedUTXOs = utxos.sort((a, b) => a.sats - b.sats)
-    const [refundableUTXOOne, refundableUTXOTwo, ...restUTXOs] = sortedUTXOs
+    const [refundableUTXOOne, refundableUTXOTwo] = sortedUTXOs
     const refundables = [refundableUTXOOne, refundableUTXOTwo].reduce((acc, curr) => (acc += curr.sats), 0)
-    const spendables = restUTXOs.reduce((acc, curr) => (acc += curr.sats), 0)
-    const eligible = refundables >= MINIMUM_AMOUNT_IN_SATS * 2 && spendables >= MINIMUM_AMOUNT_IN_SATS
+    const eligible = refundables >= MINIMUM_AMOUNT_IN_SATS * 2
 
     if (eligible) {
       this.utxos = utxos
     }
 
-    return {
-      eligible,
-      refundables,
-      spendables
-    }
+    return true
   }
 
   async build() {
-    const { eligible } = await this.isEligible()
+    const eligible = await this.isEligible()
     if (!eligible) {
       throw new Error("Not eligible")
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR includes the change that lets `PSBTBuilder` take full-control over the buyer PSBT and fetch more UTXOs as needed. However, we still check for a minimum of 3 UTXOs during the eligibility validation.