### PR TITLE
fix(sdk): temporary fix for getInscriptions

### DIFF
--- a/packages/sdk/src/modules/JsonRpcDatasource.ts
+++ b/packages/sdk/src/modules/JsonRpcDatasource.ts
@@ -56,7 +56,14 @@ export default class JsonRpcDatasource extends BaseDatasource {
   }
 
   async getInscriptions({ outpoint, decodeMetadata }: GetInscriptionsOptions) {
-    const inscriptions = await rpc[this.network].call<Inscription[]>("GetInscriptions", { outpoint }, rpc.id)
+    const { inscriptions } = await rpc[this.network].call<{
+      inscriptions: Inscription[]
+      pagination: {
+        limit: number
+        prev: string | null
+        next: string | null
+      }
+    }>("GetInscriptions", { outpoint }, rpc.id)
 
     return decodeMetadata ? DatasourceUtility.transformInscriptions(inscriptions) : inscriptions
   }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR uses the the latest response type for `GetInscriptions` RPC. This is a temporary fix and should be standardised in #68 