### PR TITLE
fix(sdk): chunk witness data wrt. bytes instead of str length

### DIFF
--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -4,3 +4,6 @@ export const MINIMUM_AMOUNT_IN_SATS = 600
 
 // Fee calculated by the fee estimator cannot be greater than 0.05 BTC in any case
 export const MAXIMUM_FEE = 5000000
+
+// Maximum number of bytes pushable to the witness stack
+export const MAXIMUM_SCRIPT_ELEMENT_SIZE = 520


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes a critical bug where the witness data (content/metadata) was being chunked based on the length of stringified data. Characters like `ō` or `å` are 2 bytes in size as opposed to a standard `o` or `a` and chunking the data based on the string length would generate a chunk that is greater in size than the max limit.

The solution implemented in this PR takes the string's byte level in consideration to generate chunks.