### PR TITLE
fix(sdk): deduct already retrieved amount

### DIFF
--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -262,7 +262,6 @@ export class PSBTBuilder extends FeeEstimator {
     this.changeAmount = Math.floor(this.inputAmount - this.outputAmount - this.fee)
 
     await this.isNegativeChange()
-    await this.calculateChangeAmount()
   }
 
   private async isNegativeChange() {

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -286,7 +286,11 @@ export class PSBTBuilder extends FeeEstimator {
     if (!this.autoAdjustment && !address) return
 
     const amountToRequest =
-      amount && amount > 0 ? amount : this.changeAmount < 0 ? this.changeAmount * -1 : this.outputAmount
+      amount && amount > 0
+        ? amount
+        : this.changeAmount < 0
+        ? this.changeAmount * -1
+        : this.outputAmount - this.getRetrievedUTXOsValue()
 
     if (amount && this.getRetrievedUTXOsValue() > amount) return
 

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -292,7 +292,7 @@ export class PSBTBuilder extends FeeEstimator {
         ? this.changeAmount * -1
         : this.outputAmount - this.getRetrievedUTXOsValue()
 
-    if (amount && this.getRetrievedUTXOsValue() > amount) return
+    if ((amount && this.getRetrievedUTXOsValue() >= amount) || amountToRequest <= 0) return
 
     const utxos = await this.datasource.getSpendables({
       address: address || this.address,


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR deducts already retrieved amount from the amount required to cover for the outputs, and network fee. Builder like `InstantTrader` that are built on top of `PSBTBuilder` retrieve UTXOs on their own, and let `PSBTBuilder` only fetch additional if there's a need.

Also, change output has been decoupled from `outputs` for keep a clear separation of user provided outputs and auto-calculated (change) output.