### PR TITLE
fix(sdk): bump taproot input size by 0.5B

### DIFF
--- a/packages/sdk/src/fee/FeeEstimator.ts
+++ b/packages/sdk/src/fee/FeeEstimator.ts
@@ -129,7 +129,7 @@ export default class FeeEstimator {
   private getBaseSizeByType(type: AddressFormats) {
     switch (type) {
       case "taproot":
-        return { input: 41.5, output: 43, txHeader: 10.5, witness: 66 } // witness size is different for non-default sigHash
+        return { input: 42, output: 43, txHeader: 10.5, witness: 66 } // witness size is different for non-default sigHash
 
       case "segwit":
         return { input: 41, output: 31, txHeader: 10.5, witness: 105 }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps input size by 0.5 Byte for Taproot to prevent a terminal/halting issue:

`min relay fee not met [minimum] < [fee-calculated-by-sdk]`

Usually the difference is merely 1 sat and everything comes to an halt. Despite the current sizes being correct, the issue persists. The idea of this PR is to over-estimate the fee slightly (no significant change).