### PR TITLE
feat(sdk): deduct royalty from seller price & cap to 10%

### DIFF
--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -7,3 +7,6 @@ export const MAXIMUM_FEE = 5000000
 
 // Maximum number of bytes pushable to the witness stack
 export const MAXIMUM_SCRIPT_ELEMENT_SIZE = 520
+
+// Maximum royalty percentage
+export const MAXIMUM_ROYALTY_PERCENTAGE = 0.1

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -1,5 +1,6 @@
 import { BaseDatasource, GetWalletOptions, Inscriber, JsonRpcDatasource, verifyMessage } from ".."
 import { Network } from "../config/types"
+import { MAXIMUM_ROYALTY_PERCENTAGE } from "../constants"
 
 export async function publishCollection({
   title,
@@ -17,8 +18,8 @@ export async function publishCollection({
   }
 
   if (royalty) {
-    // 0 = 0%, 10 = 1000%
-    if (isNaN(royalty.pct) || royalty.pct < 0 || royalty.pct > 10) {
+    // 0 = 0%, 0.1 = 10%
+    if (isNaN(royalty.pct) || royalty.pct < 0 || royalty.pct > MAXIMUM_ROYALTY_PERCENTAGE) {
       throw new Error("Invalid royalty %")
     }
 

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -52,9 +52,10 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
 
   private async generateSellerOutputs() {
     const royalty = await this.calculateRoyalty()
-    this.outputs = [{ address: this.receiveAddress || this.address, value: this.price + this.postage }]
+    const royaltyAmount = royalty && royalty.amount >= MINIMUM_AMOUNT_IN_SATS ? royalty.amount : 0
+    this.outputs = [{ address: this.receiveAddress || this.address, value: this.price + this.postage - royaltyAmount }]
 
-    if (royalty && royalty.amount >= MINIMUM_AMOUNT_IN_SATS) {
+    if (royalty && royaltyAmount) {
       this.outputs.push({
         address: royalty.address, // creator address
         value: royalty.amount // royalty in sats to be paid to original creator


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR deducts the royalty amount from seller price. So, if the seller sells an item for 100 and royalty for that item is set to 5% -- the seller would receive 95 and 5 would be sent to the creator as royalty payment.

Also, a max cap of 10% has been added. Creators can set only `royalty <= 10%`.