### PR TITLE
fix(sdk): exit when royalty is not defined

### DIFF
--- a/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuyerTxBuilder.ts
@@ -64,6 +64,8 @@ export default class InstantTradeBuyerTxBuilder extends InstantTradeBuilder {
 
   private decodeRoyalty() {
     const royaltyOutput = (this.sellerPSBT.data.globalMap.unsignedTx as any).tx.outs[1]
+    if (!royaltyOutput) return
+
     const scriptPayload = getScriptType(royaltyOutput.script, this.network).payload
     const amount = royaltyOutput && royaltyOutput.value >= MINIMUM_AMOUNT_IN_SATS ? royaltyOutput.value : 0
     const receiver = scriptPayload ? scriptPayload.address : null


### PR DESCRIPTION
#### What this PR does / why we need it:

Changes in this PR exits royalty decoding for non-royalty inscriptions.
