### PR TITLE
refactor(sdk): bump max royalty perc to 20

### DIFF
--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -9,4 +9,4 @@ export const MAXIMUM_FEE = 5000000
 export const MAXIMUM_SCRIPT_ELEMENT_SIZE = 520
 
 // Maximum royalty percentage
-export const MAXIMUM_ROYALTY_PERCENTAGE = 0.1
+export const MAXIMUM_ROYALTY_PERCENTAGE = 0.2


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps the maximum royalty percentage from 10% to 20%.