### PR TITLE
feat(ux): add readOnly optional param to unisat getAddresses method

### DIFF
--- a/packages/sdk/src/browser-wallets/unisat/addresses.ts
+++ b/packages/sdk/src/browser-wallets/unisat/addresses.ts
@@ -2,7 +2,7 @@ import { getAddressFormat } from "../.."
 import { Network } from "../../config/types"
 import { isUnisatInstalled, UnisatNetwork } from "./utils"
 
-export async function getAddresses(network: Network) {
+export async function getAddresses(network: Network, readOnly?: boolean) {
   if (!isUnisatInstalled()) {
     throw new Error("Unisat not installed.")
   }
@@ -22,7 +22,7 @@ export async function getAddresses(network: Network) {
     await window.unisat.switchNetwork(targetNetwork)
   }
 
-  const accounts = await window.unisat.requestAccounts()
+  const accounts = readOnly ? await window.unisat.getAccounts() : await window.unisat.requestAccounts()
   const publicKey = await window.unisat.getPublicKey()
 
   if (!accounts[0]) {

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -8,6 +8,7 @@ type Unisat = {
   getNetwork: () => Promise<UnisatNetwork>
   switchNetwork: (targetNetwork: UnisatNetwork) => Promise<void>
   requestAccounts: () => Promise<string[]>
+  getAccounts: () => Promise<string[]>
   getPublicKey: () => Promise<string>
   signPsbt: (hex: string, { autoFinalized }: Record<string, boolean>) => Promise<string>
   signMessage: (message: string) => Promise<string>


### PR DESCRIPTION
As per docs (https://docs.unisat.io/dev/unisat-wallet-api#getaccounts) unisat got 2 methods, one is `requestAccounts` and another is `getAccounts`. They both returning same results, but request version comes with a side-effect that also opens wallet connect if you are not connected. That results in a major UX issue in case any app wants to call this method to update addresses in the background, which results in constantly opening wallet, when it's technically not required. This param allows optionally calling readOnly version of that method, without breaking existing connection logic anywhere else.