### PR TITLE
feat(sdk): implement BRC-20 

### DIFF
--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -1,6 +1,7 @@
 import { Transaction as BTCTransaction } from "bitcoinjs-lib"
 
 import { Rarity } from "../inscription/types"
+import { JsonRpcPagination } from "../modules/types"
 import { Transaction, UTXO } from "../transactions/types"
 import { RequireAtLeastOne } from "../utils/types"
 
@@ -71,4 +72,51 @@ export interface GetSpendablesOptions {
 
 export interface GetBalanceOptions {
   address: string
+}
+
+export interface GetTokenOptions {
+  tick: string
+}
+
+export interface GetTransfersOptions {
+  filter: RequireAtLeastOne<{
+    inscription?: string
+    tick?: string
+    from?: string
+    to?: string
+  }>
+  pagination?: JsonRpcPagination
+}
+
+export interface GetTransfersResponse {
+  transfers: Array<{
+    inscription: string
+    tick: string
+    slug: string
+    amount: number
+    from: {
+      address: string
+      block: number
+      timestamp: number
+    }
+    to: {
+      address: string
+      block: number
+      timestamp: number
+    }
+  }>
+  pagination?: JsonRpcPagination
+}
+
+export interface GetAddressTokensOptions {
+  address: string
+}
+
+export interface GetAddressTokensResponse {
+  address: string
+  tick: string
+  slug: string
+  total: number
+  available: number
+  transferable: number
 }

--- a/packages/sdk/src/brc20/BRC20Deploy.ts
+++ b/packages/sdk/src/brc20/BRC20Deploy.ts
@@ -1,0 +1,110 @@
+import { Inscriber } from ".."
+import { BRC20DeployOptions, BRC20DeployPayloadAttributes } from "./types"
+
+export class BRC20Deploy extends Inscriber {
+  private tick: string
+  private supply: number
+  private limit: number
+  private decimals: number
+
+  constructor({
+    address,
+    pubKey,
+    destinationAddress,
+    feeRate,
+    network,
+    tick,
+    supply,
+    limit,
+    decimals
+  }: BRC20DeployOptions) {
+    super({
+      network,
+      address,
+      changeAddress: address,
+      destinationAddress: destinationAddress || address,
+      publicKey: pubKey,
+      feeRate,
+      postage: 1000,
+      mediaType: "", // Set on payload creation
+      mediaContent: "" // Set on payload creation
+    })
+
+    this.tick = tick
+    this.supply = supply
+    this.limit = limit
+    this.decimals = decimals
+  }
+
+  private async validateDeployOptions() {
+    if (this.decimals < 0 || this.decimals > 18) {
+      throw new Error("Invalid decimals")
+    }
+
+    if (this.limit < 0) {
+      throw new Error("Invalid limit")
+    }
+
+    if (this.supply < 0) {
+      throw new Error("Invalid supply")
+    }
+
+    if (this.tick.length < 4) {
+      throw new Error("Invalid tick")
+    }
+
+    const token = await this.datasource.getToken({ tick: this.tick })
+    if (token) {
+      throw new Error("Token already exists")
+    }
+
+    this.generatePayload()
+  }
+
+  private generatePayload() {
+    const payload: BRC20DeployPayloadAttributes = {
+      p: "brc-20",
+      op: "deploy",
+      tick: this.tick,
+      max: this.supply.toString(),
+      lim: this.limit.toString(),
+      dec: this.decimals.toString()
+    }
+
+    this.content = {
+      content: JSON.stringify(payload),
+      type: "text/plain;charset=utf-8"
+    }
+  }
+
+  async reveal() {
+    await this.validateDeployOptions()
+
+    // generate deposit address and fee for inscription
+    const { address, revealFee: amount } = await this.generateCommit()
+
+    return { address, amount }
+  }
+
+  async deploy() {
+    await this.validateDeployOptions()
+    await this.generateCommit()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+
+  async recoverFunds() {
+    await this.validateDeployOptions()
+    await this.recover()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+}

--- a/packages/sdk/src/brc20/BRC20Mint.ts
+++ b/packages/sdk/src/brc20/BRC20Mint.ts
@@ -1,0 +1,91 @@
+import { Inscriber } from ".."
+import { BRC20MintOptions, BRC20MintPayloadAttributes } from "./types"
+
+export class BRC20Mint extends Inscriber {
+  private tick: string
+  private amount = 0
+
+  constructor({ address, pubKey, destinationAddress, feeRate, network, tick, amount }: BRC20MintOptions) {
+    super({
+      network,
+      address,
+      changeAddress: address,
+      destinationAddress: destinationAddress || address,
+      publicKey: pubKey,
+      feeRate,
+      postage: 1000,
+      mediaType: "", // Set on payload creation
+      mediaContent: "" // Set on payload creation
+    })
+
+    this.tick = tick
+    this.amount = amount
+  }
+
+  private async validateMintOptions() {
+    if (isNaN(this.amount) || this.amount <= 0) {
+      throw new Error("Invalid amount")
+    }
+
+    const token = await this.datasource.getToken({ tick: this.tick })
+    if (!token) {
+      throw new Error("Invalid token")
+    }
+
+    const availableSupply = +token.max - +token.amount
+    if (availableSupply < this.amount) {
+      throw new Error(`Amount exceeds available supply of ${availableSupply} tokens`)
+    }
+
+    if (this.amount > token.limit) {
+      throw new Error(`Amount exceeds limit of ${token.limit} tokens per tx`)
+    }
+
+    this.generatePayload()
+  }
+
+  private generatePayload() {
+    const payload: BRC20MintPayloadAttributes = {
+      p: "brc-20",
+      op: "mint",
+      tick: this.tick,
+      amt: this.amount.toString()
+    }
+
+    this.content = {
+      content: JSON.stringify(payload),
+      type: "text/plain;charset=utf-8"
+    }
+  }
+
+  async reveal() {
+    await this.validateMintOptions()
+
+    // generate deposit address and fee for inscription
+    const { address, revealFee: amount } = await this.generateCommit()
+
+    return { address, amount }
+  }
+
+  async mint() {
+    await this.validateMintOptions()
+    await this.generateCommit()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+
+  async recoverFunds() {
+    await this.validateMintOptions()
+    await this.recover()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+}

--- a/packages/sdk/src/brc20/BRC20Transfer.ts
+++ b/packages/sdk/src/brc20/BRC20Transfer.ts
@@ -1,0 +1,215 @@
+import { generateTxUniqueIdentifier, Inscriber, Inscription, JsonRpcDatasource, processInput } from ".."
+import { BRC20TransferOptions, BRC20TransferPayloadAttributes } from "./types"
+
+export class BRC20Transfer extends Inscriber {
+  private tick: string
+  private amount = 0
+
+  constructor({
+    address,
+    pubKey,
+    destinationAddress,
+    datasource,
+    feeRate,
+    network,
+    tick,
+    amount
+  }: BRC20TransferOptions) {
+    super({
+      network,
+      address,
+      changeAddress: address,
+      destinationAddress: destinationAddress || address,
+      publicKey: pubKey,
+      feeRate,
+      postage: 1000,
+      mediaType: "", // Set on payload creation
+      mediaContent: "" // Set on payload creation
+    })
+
+    this.address
+    this.datasource = datasource || new JsonRpcDatasource({ network })
+    this.feeRate = feeRate
+    this.network = network
+
+    this.tick = tick
+    this.amount = amount
+  }
+
+  private async validateTransferOptions() {
+    if (isNaN(this.amount) || this.amount <= 0) {
+      throw new Error("Invalid amount")
+    }
+
+    const token = await this.datasource.getToken({ tick: this.tick })
+    if (!token) {
+      throw new Error("Invalid token")
+    }
+
+    this.generatePayload()
+  }
+
+  private generatePayload() {
+    const payload: BRC20TransferPayloadAttributes = {
+      p: "brc-20",
+      op: "transfer",
+      tick: this.tick,
+      amt: this.amount.toString()
+    }
+
+    return payload
+  }
+
+  private async getBalances() {
+    const balances = await this.datasource.getAddressTokens({
+      address: this.address
+    })
+
+    return {
+      total: balances.total,
+      available: balances.available,
+      transferable: balances.transferable
+    }
+  }
+
+  private async hasEnoughTransferableBalance() {
+    const { transferable } = await this.getBalances()
+    return transferable >= this.amount
+  }
+
+  private async hasEnoughOverallBalance() {
+    const { available } = await this.getBalances()
+    return available >= this.amount
+  }
+
+  private async findInscriptionUTXOs() {
+    const [inscriptionIds, { unspendableUTXOs }] = await Promise.all([
+      this.findTokenBalanceInscriptions(),
+      this.datasource.getUnspents({
+        address: this.address
+      })
+    ])
+
+    return unspendableUTXOs.filter((utxo) => {
+      return inscriptionIds.includes(generateTxUniqueIdentifier(utxo.txid, utxo.n))
+    })
+  }
+
+  private async prepareInscriptionsToTransfer() {
+    const utxos = await this.findInscriptionUTXOs()
+    if (!utxos.length) {
+      throw new Error("No token balance inscriptions found")
+    }
+
+    const promises = utxos.map((utxo) =>
+      processInput({
+        utxo,
+        pubKey: this.publicKey,
+        network: this.network,
+        datasource: this.datasource
+      })
+    )
+
+    this.inputs = await Promise.all(promises)
+    this.outputs = utxos.map((utxo) => ({
+      address: this.destinationAddress,
+      value: utxo.sats
+    }))
+  }
+
+  private pickBRC20Inscriptions(inscriptions: Inscription[]) {
+    const filterInscriptions: Array<Inscription & { content: BRC20TransferPayloadAttributes }> = []
+    for (const inscription of inscriptions) {
+      const isBRC20Inscription =
+        inscription.mediaType === "text/plain;charset=utf-8" &&
+        inscription.mediaContent.includes("brc-20") &&
+        inscription.mediaContent.includes("transfer")
+
+      if (!isBRC20Inscription) continue
+
+      try {
+        const content = JSON.parse(inscription.mediaContent) as BRC20TransferPayloadAttributes
+        if (content.amt !== this.amount.toString()) {
+          filterInscriptions.push({
+            ...inscription,
+            content
+          })
+        }
+      } catch (_) {
+        continue
+      }
+    }
+
+    // Sort inscriptions to spend highest amount transfer ticket first
+    return filterInscriptions.sort((a, b) => +b.content.amt - +a.content.amt)
+  }
+
+  private async findTokenBalanceInscriptions() {
+    const inscriptions = await this.datasource.getInscriptions({
+      owner: this.address
+    })
+    const brc20Inscriptions = this.pickBRC20Inscriptions(inscriptions)
+
+    const balanceInscriptions = []
+    let total = 0
+    let currentIndex = 0
+    while (this.amount > total && brc20Inscriptions[currentIndex]) {
+      const inscription = brc20Inscriptions[currentIndex]
+      balanceInscriptions.push(inscription)
+      total += +inscription.content.amt
+      currentIndex++
+    }
+
+    return balanceInscriptions.map((inscription) => inscription.id)
+  }
+
+  async reveal() {
+    const isOverallBalanceSufficient = await this.hasEnoughOverallBalance()
+    if (isOverallBalanceSufficient) return
+
+    await this.validateTransferOptions()
+
+    // generate deposit address and fee for inscription
+    const { address, revealFee: amount } = await this.generateCommit()
+
+    return { address, amount }
+  }
+
+  async generate() {
+    const isOverallBalanceSufficient = await this.hasEnoughOverallBalance()
+    if (isOverallBalanceSufficient) return
+
+    await this.validateTransferOptions()
+    await this.generateCommit()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+
+  async transfer() {
+    const isTransferableBalanceSufficient = await this.hasEnoughTransferableBalance()
+    if (!isTransferableBalanceSufficient) {
+      throw new Error("Insufficient transferable balance")
+    }
+
+    await this.validateTransferOptions()
+    await this.prepareInscriptionsToTransfer()
+    await this.prepare()
+
+    return this.toHex()
+  }
+
+  async recoverFunds() {
+    await this.validateTransferOptions()
+    await this.recover()
+
+    const isReady = await this.isReady()
+    if (isReady) {
+      await this.build()
+      return this.toHex()
+    }
+  }
+}

--- a/packages/sdk/src/brc20/index.ts
+++ b/packages/sdk/src/brc20/index.ts
@@ -1,0 +1,4 @@
+export * from "./BRC20Deploy"
+export * from "./BRC20Mint"
+export * from "./BRC20Transfer"
+export * from "./types"

--- a/packages/sdk/src/brc20/types.ts
+++ b/packages/sdk/src/brc20/types.ts
@@ -1,0 +1,71 @@
+import { BaseDatasource } from ".."
+import { Network } from "../config/types"
+
+export type BRC20Options<T> = {
+  datasource: BaseDatasource
+  feeRate: number
+  network: Network
+} & T
+
+export type BRC20DeployOptions = BRC20Options<{
+  address: string
+  pubKey: string
+  destinationAddress?: string
+  tick: string
+  supply: number
+  limit: number
+  decimals: number
+}>
+
+export type BRC20MintOptions = BRC20Options<{
+  address: string
+  pubKey: string
+  destinationAddress?: string
+  tick: string
+  amount: number
+}>
+
+export type BRC20TransferOptions = BRC20Options<{
+  address: string
+  pubKey: string
+  destinationAddress: string
+  tick: string
+  amount: number
+}>
+
+export type BRC20Operations = "deploy" | "mint" | "transfer"
+
+export type BRC20Base<T> = {
+  p: "brc-20"
+  tick: string
+  op: BRC20Operations
+} & T
+
+export type BRC20DeployPayloadAttributes = BRC20Base<{
+  op: "deploy"
+  max: string
+  lim?: string
+  dec?: string
+}>
+
+export type BRC20MintPayloadAttributes = BRC20Base<{
+  op: "mint"
+  amt: string
+}>
+
+export type BRC20TransferPayloadAttributes = BRC20Base<{
+  op: "transfer"
+  amt: string
+}>
+
+export interface BRC20TokenAttributes {
+  inscription: string
+  tick: string
+  slug: string
+  max: number // should be string after BigNumber is implemented
+  amount: number // should be string after BigNumber is implemented
+  limit: number
+  decimal: number
+  creator: string
+  timestamp: number
+}

--- a/packages/sdk/src/modules/BaseDatasource.ts
+++ b/packages/sdk/src/modules/BaseDatasource.ts
@@ -2,16 +2,22 @@ import { Transaction as BTCTransaction } from "bitcoinjs-lib"
 
 import { Inscription } from ".."
 import {
+  GetAddressTokensOptions,
+  GetAddressTokensResponse,
   GetBalanceOptions,
   GetInscriptionOptions,
   GetInscriptionsOptions,
   GetInscriptionUTXOOptions,
   GetSpendablesOptions,
+  GetTokenOptions,
+  GetTransfersOptions,
+  GetTransfersResponse,
   GetTxOptions,
   GetUnspentsOptions,
   GetUnspentsResponse,
   RelayOptions
 } from "../api/types"
+import { BRC20TokenAttributes } from "../brc20/types"
 import { Network } from "../config/types"
 import { Transaction, UTXO, UTXOLimited } from "../transactions/types"
 
@@ -57,4 +63,11 @@ export default abstract class BaseDatasource {
   abstract getUnspents({ address, type, rarity, sort, limit, next }: GetUnspentsOptions): Promise<GetUnspentsResponse>
 
   abstract relay({ hex, maxFeeRate, validate }: RelayOptions): Promise<string>
+
+  // BRC-20 methods
+  abstract getToken({ tick }: GetTokenOptions): Promise<BRC20TokenAttributes>
+
+  abstract getTransfers({ filter, pagination }: GetTransfersOptions): Promise<GetTransfersResponse>
+
+  abstract getAddressTokens({ address }: GetAddressTokensOptions): Promise<GetAddressTokensResponse>
 }

--- a/packages/sdk/src/modules/JsonRpcDatasource.ts
+++ b/packages/sdk/src/modules/JsonRpcDatasource.ts
@@ -3,16 +3,22 @@ import { Transaction as BTCTransaction } from "bitcoinjs-lib"
 import { Inscription } from ".."
 import { rpc } from "../api/jsonrpc"
 import {
+  GetAddressTokensOptions,
+  GetAddressTokensResponse,
   GetBalanceOptions,
   GetInscriptionOptions,
   GetInscriptionsOptions,
   GetInscriptionUTXOOptions,
   GetSpendablesOptions,
+  GetTokenOptions,
+  GetTransfersOptions,
+  GetTransfersResponse,
   GetTxOptions,
   GetUnspentsOptions,
   GetUnspentsResponse,
   RelayOptions
 } from "../api/types"
+import { BRC20TokenAttributes } from "../brc20/types"
 import { Network } from "../config/types"
 import { Transaction, UTXO, UTXOLimited } from "../transactions/types"
 import { BaseDatasource, DatasourceUtility } from "."
@@ -199,5 +205,45 @@ export default class JsonRpcDatasource extends BaseDatasource {
     }
 
     return rpc[this.network].call<string>("Transactions.Relay", { hex, maxFeeRate, validate }, rpc.id)
+  }
+
+  // BRC-20 methods
+  async getToken({ tick }: GetTokenOptions): Promise<BRC20TokenAttributes> {
+    if (!tick) {
+      throw new Error("Invalid request")
+    }
+
+    return rpc[this.network].call<BRC20TokenAttributes>("BRC20.GetToken", { tick }, rpc.id)
+  }
+
+  async getTransfers({ filter, pagination }: GetTransfersOptions): Promise<GetTransfersResponse> {
+    if (!filter) {
+      throw new Error("Invalid request")
+    }
+
+    const { transfers, pagination: _pagination } = await rpc[this.network].call<{
+      transfers: GetTransfersResponse["transfers"]
+      pagination: JsonRpcPagination
+    }>(
+      "Brc20.GetTransfers",
+      {
+        filter,
+        pagination
+      },
+      rpc.id
+    )
+
+    return {
+      transfers,
+      pagination: _pagination
+    }
+  }
+
+  async getAddressTokens({ address }: GetAddressTokensOptions): Promise<GetAddressTokensResponse> {
+    if (!address) {
+      throw new Error("Invalid request")
+    }
+
+    return rpc[this.network].call<GetAddressTokensResponse>("Brc20.GetAddressTokens", { address }, rpc.id)
   }
 }

--- a/packages/sdk/src/transactions/Inscriber.ts
+++ b/packages/sdk/src/transactions/Inscriber.ts
@@ -23,10 +23,10 @@ export class Inscriber extends PSBTBuilder {
   protected mediaContent: string
   protected meta?: NestedObject
   protected postage: number
+  protected destinationAddress: string
 
   private ready = false
   private commitAddress: string | null = null
-  private destinationAddress: string
   private payment: bitcoin.payments.Payment | null = null
   private suitableUnspent: UTXOLimited | null = null
   private recovery = false
@@ -40,6 +40,7 @@ export class Inscriber extends PSBTBuilder {
   }
   private taprootTree!: [Tapleaf, Tapleaf]
 
+  // TODO: bind datasource to constructor options
   constructor({
     network,
     address,
@@ -87,6 +88,11 @@ export class Inscriber extends PSBTBuilder {
       outputAmount: this.outputAmount,
       postage: this.postage
     }
+  }
+
+  set content({ content, type }: SetContentOptions) {
+    this.mediaContent = content
+    this.mediaType = type
   }
 
   private getMetadata() {
@@ -290,6 +296,11 @@ export type InscriberArgOptions = Pick<GetWalletOptions, "safeMode"> & {
   meta?: NestedObject
   outputs?: Outputs
   encodeMetadata?: boolean
+}
+
+interface SetContentOptions {
+  content: string
+  type: string
 }
 
 type Outputs = Array<{ address: string; value: number }>


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR implements the [BRC-20 tokens experiment](https://domo-2.gitbook.io/brc-20-experiment/) which is a theoretical clone of ERC-20 on Ethereum. While, ERC-20 is completely based on smart contracts -- BRC-20 works on consensus of brc-20 indexers that tracks and maintains balances and transfers. 

BRC-20 works on 3 process flows:
1. Deploy: launch a new token on brc-20
2. Mint: mint tokens from the available supply
3. Transfer: transfer/trade tokens between two parties

All of the above 3 process flows have been implemented in this PR. 

**Note: There are many edge cases that haven't been tested yet, so please proceed to use this branch w/ caution.**