### PR TITLE
feat(sdk): integrate bip322-js to sign & verify non-legacy address messages

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.0.2",
     "bip32": "4.0.0",
+    "bip322-js": "^1.1.0",
     "bip39": "3.1.0",
     "bitcoinjs-lib": "6.1.3",
     "bitcoinjs-message": "2.2.0",

--- a/packages/sdk/src/browser-wallets/metamask/signatures.ts
+++ b/packages/sdk/src/browser-wallets/metamask/signatures.ts
@@ -1,3 +1,4 @@
+import { Address, Signer } from "bip322-js"
 import { Psbt } from "bitcoinjs-lib"
 import { sign } from "bitcoinjs-message"
 import { ethers } from "ethers"
@@ -86,7 +87,9 @@ export async function signMessage(options: SignMetaMaskMessageOptions) {
   const node = await getDerivedNodeFromMetaMaskSignature(signature, "", options.network)
   const { address: addressBtc } = createTransaction(node.parent.publicKey, "p2pkh", options.network)
 
-  const signedMessage = sign(options.message, node.parent.privateKey!)
+  const signedMessage = Address.isP2PKH(address)
+    ? sign(options.message, node.parent.privateKey!)
+    : Signer.sign(node.parent.privateKey!.toString(), address, options.message)
 
   return {
     hex: signedMessage.toString("hex"),

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -232,7 +232,7 @@ export class Ordit {
   }
 
   signMessage(message: string) {
-    const legacyWallet = this.allAddresses.find((wallet) => wallet.format === "legacy") as Account
+    const legacyWallet = this.allAddresses.find((wallet) => wallet.format === this.selectedAddressType) as Account
     const signature = BIP22Address.isP2PKH(legacyWallet.address!)
       ? sign(message, legacyWallet.child.privateKey!, false)
       : Signer.sign(legacyWallet.child.privateKey!.toString(), legacyWallet.address!, message)

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -232,10 +232,10 @@ export class Ordit {
   }
 
   signMessage(message: string) {
-    const legacyWallet = this.allAddresses.find((wallet) => wallet.format === this.selectedAddressType) as Account
-    const signature = BIP22Address.isP2PKH(legacyWallet.address!)
-      ? sign(message, legacyWallet.child.privateKey!, false)
-      : Signer.sign(legacyWallet.child.privateKey!.toString(), legacyWallet.address!, message)
+    const node = this.allAddresses.find((wallet) => wallet.format === this.selectedAddressType) as Account
+    const signature = BIP22Address.isP2PKH(node.address!)
+      ? sign(message, node.child.privateKey!)
+      : Signer.sign(node.child.toWIF(), node.address!, message, getNetwork(this.#network))
 
     return signature.toString("base64")
   }

--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -1,6 +1,7 @@
 import * as ecc from "@bitcoinerlab/secp256k1"
 import BIP32Factory, { BIP32Interface } from "bip32"
 import { mnemonicToSeedSync } from "bip39"
+import { Address as BIP22Address, Signer } from "bip322-js"
 import * as bitcoin from "bitcoinjs-lib"
 import { isTaprootInput } from "bitcoinjs-lib/src/psbt/bip371"
 import { sign } from "bitcoinjs-message"
@@ -232,7 +233,9 @@ export class Ordit {
 
   signMessage(message: string) {
     const legacyWallet = this.allAddresses.find((wallet) => wallet.format === "legacy") as Account
-    const signature = sign(message, legacyWallet.child.privateKey!, false)
+    const signature = BIP22Address.isP2PKH(legacyWallet.address!)
+      ? sign(message, legacyWallet.child.privateKey!, false)
+      : Signer.sign(legacyWallet.child.privateKey!.toString(), legacyWallet.address!, message)
 
     return signature.toString("base64")
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       bip32:
         specifier: 4.0.0
         version: 4.0.0
+      bip322-js:
+        specifier: ^1.1.0
+        version: 1.1.0
       bip39:
         specifier: 3.1.0
         version: 3.1.0
@@ -529,6 +532,17 @@ packages:
   /bip174@2.1.0:
     resolution: {integrity: sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==}
     engines: {node: '>=8.0.0'}
+    dev: false
+
+  /bip322-js@1.1.0:
+    resolution: {integrity: sha512-Nxyw4lnhh4qm/zitfagJYpO7HofkABbt7Cce+Wiy4PGeilJ/hOvtqM0pxmTZxMoOhRnvDPZ55NzkFPrsyq43ew==}
+    dependencies:
+      '@bitcoinerlab/secp256k1': 1.0.2
+      bitcoinjs-lib: 6.1.3
+      bitcoinjs-message: 2.2.0
+      ecpair: 2.1.0
+      fast-sha256: 1.3.0
+      secp256k1: 5.0.0
     dev: false
 
   /bip32@4.0.0:
@@ -1207,6 +1221,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+    dev: false
+
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
@@ -1812,6 +1830,10 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+    dev: false
+
   /node-fetch@2.6.11:
     resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
     engines: {node: 4.x || >=6.0.0}
@@ -1822,6 +1844,11 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
+
+  /node-gyp-build@4.6.1:
+    resolution: {integrity: sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==}
+    hasBin: true
     dev: false
 
   /normalize-package-data@3.0.3:
@@ -2098,6 +2125,16 @@ packages:
       elliptic: 6.5.4
       nan: 2.17.0
       safe-buffer: 5.2.1
+    dev: false
+
+  /secp256k1@5.0.0:
+    resolution: {integrity: sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==}
+    engines: {node: '>=14.0.0'}
+    requiresBuild: true
+    dependencies:
+      elliptic: 6.5.4
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.6.1
     dev: false
 
   /semver@6.3.0:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR installs & integrates [bip322-js](https://github.com/ACken2/bip322-js) lib to sign and verify messages generated using `p2wpkh`, `p2sh-p2wpkh`, and single-key-spend `p2tr` addresses.

[bitcoinjs-message](https://github.com/bitcoinjs/bitcoinjs-message) only supports `p2pkh` and despite their latest support to segwit, we would like to keep the segregation of libs that are capable to handle and well-designed for a specific purpose.

[BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) outlines the approach bip322-js follows to enable message signing and verification for non-legacy addresses.