### PR TITLE
feat(unisat): extend message signer to accept type

### DIFF
--- a/packages/sdk/src/browser-wallets/types.ts
+++ b/packages/sdk/src/browser-wallets/types.ts
@@ -2,3 +2,5 @@ export interface BrowserWalletSignPSBTResponse {
   hex: string
   base64: string | null
 }
+
+export type MessageSignatureTypes = "bip322-simple" | "ecdsa"

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -1,6 +1,6 @@
 import { Psbt } from "bitcoinjs-lib"
 
-import { BrowserWalletSignPSBTResponse } from "../types"
+import { BrowserWalletSignPSBTResponse, MessageSignatureTypes } from "../types"
 import { UnisatSignPSBTOptions } from "./types"
 import { isUnisatInstalled } from "./utils"
 
@@ -30,12 +30,12 @@ export async function signPsbt(
   }
 }
 
-export async function signMessage(message: string) {
+export async function signMessage(message: string, type: MessageSignatureTypes) {
   if (!isUnisatInstalled()) {
     throw new Error("Unisat not installed.")
   }
 
-  const signature = await window.unisat.signMessage(message)
+  const signature = await window.unisat.signMessage(message, type)
 
   if (!signature) {
     throw new Error("Failed to sign message using Unisat.")

--- a/packages/sdk/src/browser-wallets/unisat/signatures.ts
+++ b/packages/sdk/src/browser-wallets/unisat/signatures.ts
@@ -30,13 +30,12 @@ export async function signPsbt(
   }
 }
 
-export async function signMessage(message: string, type: MessageSignatureTypes) {
+export async function signMessage(message: string, type: MessageSignatureTypes = "ecdsa") {
   if (!isUnisatInstalled()) {
     throw new Error("Unisat not installed.")
   }
 
   const signature = await window.unisat.signMessage(message, type)
-
   if (!signature) {
     throw new Error("Failed to sign message using Unisat.")
   }

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -11,7 +11,7 @@ type Unisat = {
   getAccounts: () => Promise<string[]>
   getPublicKey: () => Promise<string>
   signPsbt: (hex: string, { autoFinalized }: Record<string, boolean>) => Promise<string>
-  signMessage: (message: string) => Promise<string>
+  signMessage: (message: string, type: MessageSignatureTypes) => Promise<string>
 }
 
 type MetaMask = {


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR extends the Unisat message signer to accept signature type. 

With the latest addition of `bip322` in #91 to enable message signing and verification for non-legacy addresses, signature verification would fail because Unisat generates `ecdsa` signatures and verification in Ordit-SDK is done using bip322-js (for non-legacy signatures) which uses [bip322 strategy](https://bips.xyz/322).