### PR TITLE
refactor(sdk): accept address type to sign message to override default

### DIFF
--- a/packages/sdk/src/wallet/Ordit.ts
+++ b/packages/sdk/src/wallet/Ordit.ts
@@ -231,8 +231,9 @@ export class Ordit {
     return psbt.toHex()
   }
 
-  signMessage(message: string) {
-    const node = this.allAddresses.find((wallet) => wallet.format === this.selectedAddressType) as Account
+  signMessage(message: string, type?: AddressFormats) {
+    const addressType = type || this.selectedAddressType
+    const node = this.allAddresses.find((wallet) => wallet.format === addressType) as Account
     const signature = BIP22Address.isP2PKH(node.address!)
       ? sign(message, node.child.privateKey!)
       : Signer.sign(node.child.toWIF(), node.address!, message, getNetwork(this.#network))


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, the `Ordit.signMessage` method signs message w/ the keypair corresponding to the selected address type. This PR improves that by letting the SDK consumer sign message w/ a different address type and keypair w\ having the consumer to `setDefaultAddress(x)` / switch to a different type.