### PR TITLE
feat(sdk): feat: implement official CBOR based metadata

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,6 +30,7 @@
     "bitcoinjs-lib": "6.1.3",
     "bitcoinjs-message": "2.2.0",
     "buffer-reverse": "^1.0.1",
+    "cbor-js": "^0.1.0",
     "cross-fetch": "3.1.6",
     "ecpair": "2.1.0",
     "ethers": "6.6.1",

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -22,3 +22,8 @@ type MetaMask = {
 declare module "buffer-reverse" {
   export = (_: Buffer): Buffer => {}
 }
+
+declare module "cbor-js" {
+  function encode(object: NestedObject): ArrayBuffer
+  function decode(data: ArrayBuffer): NestedObject
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@sadoprotocol/ordit-sdk':
         specifier: workspace
         version: link:../../packages/sdk
+      cbor-js:
+        specifier: ^0.1.0
+        version: 0.1.0
 
   packages/sdk:
     dependencies:
@@ -47,6 +50,9 @@ importers:
       buffer-reverse:
         specifier: ^1.0.1
         version: 1.0.1
+      cbor-js:
+        specifier: ^0.1.0
+        version: 0.1.0
       cross-fetch:
         specifier: 3.1.6
         version: 3.1.6
@@ -689,6 +695,10 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
     dev: true
+
+  /cbor-js@0.1.0:
+    resolution: {integrity: sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==}
+    dev: false
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR implements the the official [CBOR-based metadata](https://docs.ordinals.com/inscriptions/metadata.html). Once merged, Ordit-SDK will be bidding goodbye to [OIP-1](https://github.com/oipsio/oips/blob/main/oip-01-inscription-metadata.md).