### PR TITLE
fix(SDK): remove assumptions from getInscriptions and utxo RPC

### DIFF
--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -50,22 +50,12 @@ export async function publishCollection({
 }
 
 export async function mintFromCollection(options: MintFromCollectionOptions) {
-  if (!options.collectionOutpoint || !options.inscriptionIid || !options.destinationAddress) {
+  if (!options.collectionInscriptionId || !options.inscriptionIid || !options.destinationAddress) {
     throw new OrditSDKError("Invalid options supplied.")
   }
 
-  const [colTxId, colVOut] = options.collectionOutpoint.split(":").map((v, i) => {
-    if (i === 0) return v
-
-    const value = parseInt(v)
-    return isNaN(value) || (!value && value !== 0) ? false : value
-  }) as [string, number | false]
-
-  if (!colTxId || colVOut === false) {
-    throw new OrditSDKError("Invalid collection outpoint supplied.")
-  }
   const datasource = options.datasource || new JsonRpcDatasource({ network: options.network })
-  const collection = await datasource.getInscription({ id: options.collectionOutpoint })
+  const collection = await datasource.getInscription({ id: options.collectionInscriptionId })
   if (!collection) {
     throw new OrditSDKError("Invalid collection")
   }
@@ -167,7 +157,7 @@ export type MintFromCollectionOptions = Pick<GetWalletOptions, "safeMode"> & {
   mediaContent: string
   destinationAddress: string
   changeAddress: string
-  collectionOutpoint: string
+  collectionInscriptionId: string
   inscriptionIid: string
   nonce: number
   publisherIndex: number

--- a/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeBuilder.ts
@@ -100,9 +100,9 @@ export default class InstantTradeBuilder extends PSBTBuilder {
       throw new OrditSDKError("Inscription not found")
     }
 
-    const utxo = await this.datasource.getInscriptionUTXO({ id: this.inscription.genesis })
+    const utxo = await this.datasource.getInscriptionUTXO({ id: this.inscription.id })
     if (!utxo) {
-      throw new OrditSDKError(`Unable to find UTXO: ${this.inscription.outpoint}`)
+      throw new OrditSDKError(`Unable to find UTXO: ${this.inscription.id}`)
     }
 
     this.postage = utxo.sats

--- a/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
+++ b/packages/sdk/src/instant-trade/InstantTradeSellerTxBuilder.ts
@@ -68,8 +68,8 @@ export default class InstantTradeSellerTxBuilder extends InstantTradeBuilder {
     if (!this.inscription || !this.inscription.meta?.col) {
       return
     }
-
-    const collection = await this.datasource.getInscription({ id: this.inscription.meta.col as string })
+    const inscriptionId = `${this.inscription.meta.col}i0` // assumes that collection inscription is always minted as the first
+    const collection = await this.datasource.getInscription({ id: inscriptionId })
     const royalty = collection.meta?.royalty
     if (!royalty || !royalty.address || !royalty.pct) {
       return

--- a/packages/sdk/src/modules/JsonRpcDatasource.ts
+++ b/packages/sdk/src/modules/JsonRpcDatasource.ts
@@ -41,8 +41,6 @@ export default class JsonRpcDatasource extends BaseDatasource {
       throw new OrditSDKError("Invalid request")
     }
 
-    id = id.includes(":") ? id.replace(":", "i") : !id.includes("i") ? `${id}i0` : id
-
     let inscription = await rpc[this.network].call<Inscription>("Ordinals.GetInscription", { id }, rpc.id)
     if (decodeMetadata) {
       inscription = DatasourceUtility.transformInscriptions([inscription])[0]
@@ -55,8 +53,6 @@ export default class JsonRpcDatasource extends BaseDatasource {
     if (!id) {
       throw new OrditSDKError("Invalid request")
     }
-
-    id = id.includes(":") ? id.replace(":", "i") : !id.includes("i") ? `${id}i0` : id
 
     return rpc[this.network].call<UTXO>("Ordinals.GetInscriptionUtxo", { id }, rpc.id)
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

accepts `collectionInscriptionId` instead of outpoint for minting.
removes assumption of `i0` due to pointers and delegates from RPC

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors 
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
