### PR TITLE
feat(sdk): support bulk minting with pointers

### DIFF
--- a/examples/node/inscribeV2.js
+++ b/examples/node/inscribeV2.js
@@ -1,0 +1,65 @@
+import { bulkMintFromCollection, InscriberV2, JsonRpcDatasource } from "@sadoprotocol/ordit-sdk"
+import { Inscriber, Ordit } from "@sadoprotocol/ordit-sdk"
+
+const MNEMONIC = "<mnemonic>"
+const network = "testnet"
+const datasource = new JsonRpcDatasource({ network })
+
+async function main() {
+  // init wallet
+  const serverWallet = new Ordit({
+    bip39: MNEMONIC,
+    network
+  })
+
+  serverWallet.setDefaultAddress("taproot")
+
+  const ordinalReceiverAddress = "<address>"
+  const paymentRefundAddress = "<address>"
+
+  // new inscription tx
+  const transaction = await bulkMintFromCollection({
+    address: serverWallet.selectedAddress,
+    publicKey: serverWallet.publicKey,
+    publisherAddress: serverWallet.selectedAddress,
+    collectionGenesis: "df91a6386fb9b55bd754d6ec49e97e1be4c80ac49e4242ff773634e4c23cc427",
+    changeAddress: paymentRefundAddress,
+    feeRate: 10,
+    outputs: [{ address: ordinalReceiverAddress, value: 999 }],
+    network,
+    datasource,
+    taptreeVersion: "3",
+    inscriptions: [
+      {
+        mediaContent: "Hello World",
+        mediaType: "text/plain",
+        postage: 1000,
+        nonce: 0,
+        receiverAddress: ordinalReceiverAddress,
+        iid: "testhello",
+        signature: "sig"
+      }
+    ]
+  })
+
+  // generate deposit address and fee for inscription
+  const revealed = await transaction.generateCommit()
+  console.log(revealed) // deposit revealFee to address
+
+  // confirm if deposit address has been funded
+  const ready = await transaction.isReady()
+
+  if (ready || transaction.ready) {
+    // build transaction
+    await transaction.build()
+
+    // sign transaction
+    const signedTxHex = serverWallet.signPsbt(transaction.toHex(), { isRevealTx: true })
+
+    // Broadcast transaction
+    const tx = await datasource.relay({ hex: signedTxHex })
+    console.log(tx)
+  }
+}
+
+main()

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "inscribe": "node inscribe",
+    "inscribeV2": "node inscribeV2",
     "read": "node read",
     "send": "node send",
     "create-psbt": "node create-psbt",

--- a/packages/sdk/src/inscription/collection.ts
+++ b/packages/sdk/src/inscription/collection.ts
@@ -269,7 +269,7 @@ export type BulkMintFromCollectionOptions = {
   publisherAddress: string
 }
 
-type InscriptionsToMint = {
+export type InscriptionsToMint = {
   nonce: number
   mediaContent: string
   mediaType: string

--- a/packages/sdk/src/inscription/encoding.ts
+++ b/packages/sdk/src/inscription/encoding.ts
@@ -1,0 +1,50 @@
+import { splitInscriptionId } from "../utils"
+
+export function trimTrailingZeroBytes(buffer: Buffer): Buffer {
+  let trimmedBuffer = buffer
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    // find the first non-zero byte
+    if (buffer[i] !== 0) {
+      trimmedBuffer = buffer.subarray(0, i + 1)
+      break
+    }
+  }
+  return trimmedBuffer
+}
+
+export function encodePointer(num: number | string | bigint): Buffer {
+  const buffer = Buffer.allocUnsafe(8)
+  buffer.writeBigUInt64LE(BigInt(num))
+  return trimTrailingZeroBytes(buffer)
+}
+
+export function encodeTag(tag: number): Buffer {
+  let tagInHex = tag.toString(16)
+  // ensure even length or Buffer.from will remove odd length bytes
+  if (tagInHex.length % 2 !== 0) {
+    tagInHex = "0" + tagInHex
+  }
+  return Buffer.from(tagInHex, "hex")
+}
+
+function reverseBufferByteChunks(src: Buffer): Buffer {
+  const buffer = Buffer.from(src)
+  return buffer.reverse()
+}
+
+export function encodeInscriptionId(inscriptionId: string): Buffer {
+  const { txId, index } = splitInscriptionId(inscriptionId)
+
+  // reverse txId byte
+  const txidBuffer = Buffer.from(txId, "hex")
+  const reversedTxIdBuffer = reverseBufferByteChunks(txidBuffer)
+
+  // Convert index to little-endian, max 4 bytes
+  const indexBuffer = Buffer.alloc(4)
+  indexBuffer.writeUInt32LE(index)
+
+  // Trim trailing zero bytes
+  const trimmedIndexBuffer = trimTrailingZeroBytes(indexBuffer)
+
+  return Buffer.concat([reversedTxIdBuffer, trimmedIndexBuffer])
+}

--- a/packages/sdk/src/inscription/meta.ts
+++ b/packages/sdk/src/inscription/meta.ts
@@ -1,0 +1,22 @@
+export interface MetaParams {
+  collectionGenesis: string
+  iid: string
+  publisher: string
+  nonce: number
+  receiverAddress: string
+  signature?: string
+}
+
+export function buildMeta({ collectionGenesis, iid, publisher, nonce, receiverAddress, signature }: MetaParams) {
+  return {
+    p: "vord",
+    v: 1,
+    ty: "insc",
+    col: collectionGenesis,
+    iid,
+    publ: publisher,
+    nonce: nonce,
+    minter: receiverAddress,
+    sig: signature
+  }
+}

--- a/packages/sdk/src/inscription/types.ts
+++ b/packages/sdk/src/inscription/types.ts
@@ -47,3 +47,12 @@ export interface InputsToSign {
   signingIndexes: number[]
   sigHash?: number
 }
+
+export interface EnvelopeOpts {
+  mediaContent?: string
+  mediaType?: string
+  pointer?: string
+  delegateInscriptionId?: string
+  receiverAddress: string
+  postage: number
+}

--- a/packages/sdk/src/inscription/witness.ts
+++ b/packages/sdk/src/inscription/witness.ts
@@ -3,6 +3,18 @@ import * as bitcoin from "bitcoinjs-lib"
 
 import { MAXIMUM_SCRIPT_ELEMENT_SIZE } from "../constants"
 import { OrditSDKError } from "../utils/errors"
+import { encodeInscriptionId, encodePointer, encodeTag } from "./encoding"
+import { EnvelopeOpts } from "./types"
+
+export const INSCRIPTION_FIELD_TAG = {
+  ContentType: encodeTag(1),
+  Pointer: encodeTag(2),
+  Parent: encodeTag(3),
+  Metadata: encodeTag(5),
+  Metaprotocol: encodeTag(7),
+  ContentEncoding: encodeTag(9),
+  Delegate: encodeTag(11)
+}
 
 export function buildWitnessScript({ recover = false, ...options }: WitnessScriptOptions) {
   bitcoin.initEccLib(ecc)
@@ -59,6 +71,30 @@ export function buildWitnessScript({ recover = false, ...options }: WitnessScrip
   ])
 }
 
+export function buildWitnessScriptV2({ xkey, envelopes }: WitnessScriptV2Options) {
+  bitcoin.initEccLib(ecc)
+  if (!xkey) {
+    throw new OrditSDKError("xkey is required to build witness script")
+  }
+
+  const envelopesStackElements:(number | Buffer)[] = []
+  // build all envelopes
+  for (const envelopeOpt of envelopes) {
+    const envelope = buildEnvelope(envelopeOpt)
+    envelopesStackElements.push(...envelope)
+  }
+
+  return bitcoin.script.compile([
+    Buffer.from(xkey, "hex"),
+    bitcoin.opcodes.OP_CHECKSIG,
+    ...envelopesStackElements
+  ])
+}
+
+export function buildRecoverWitnessScript(xkey: string) {
+  return bitcoin.script.compile([Buffer.from(xkey, "hex"), bitcoin.opcodes.OP_CHECKSIG])
+}
+
 function opPush(data: string | Buffer) {
   const buff = Buffer.isBuffer(data) ? data : Buffer.from(data, "utf8")
   if (buff.byteLength > MAXIMUM_SCRIPT_ELEMENT_SIZE)
@@ -81,10 +117,59 @@ export const chunkContent = function (str: string, encoding: BufferEncoding = "u
   return chunks
 }
 
+export const buildEnvelope = function ({delegateInscriptionId,mediaContent,mediaType,pointer}: EnvelopeOpts) {
+  if (!delegateInscriptionId && !mediaContent && !mediaType) {
+    throw new OrditSDKError("mediaContent and mediaType are required to build an envelope")
+  }
+  if (!!delegateInscriptionId && !!mediaContent && !!mediaType) {
+    throw new OrditSDKError("Cannot build an envelope with both media content and a delegate inscription id")
+  }
+
+  const baseStackElements = [
+    bitcoin.opcodes.OP_FALSE,
+    bitcoin.opcodes.OP_IF,
+    opPush("ord"),
+  ]
+
+  if (pointer) {
+    baseStackElements.push(
+      INSCRIPTION_FIELD_TAG.Pointer,
+      encodePointer(pointer)
+    )
+  }
+
+  if (delegateInscriptionId) {
+    baseStackElements.push(
+      INSCRIPTION_FIELD_TAG.Delegate,
+      encodeInscriptionId(delegateInscriptionId)
+    )
+  }
+
+  // TODO: support other tags (Parent, Metadata, Metaprotocol, ContentEncoding)
+
+  if (mediaContent && mediaType) {
+    baseStackElements.push(
+      INSCRIPTION_FIELD_TAG.ContentType,
+      opPush(mediaType),
+      bitcoin.opcodes.OP_0,
+      ...chunkContent(mediaContent, !mediaType.includes("text") ? "base64" : "utf8")
+    )
+  }
+
+  // END
+  baseStackElements.push(bitcoin.opcodes.OP_ENDIF)
+  return baseStackElements
+}
+
 export type WitnessScriptOptions = {
   xkey: string
   mediaContent: string
   mediaType: string
   meta: any
   recover?: boolean
+}
+
+export type WitnessScriptV2Options = {
+  xkey: string
+  envelopes: EnvelopeOpts[]
 }

--- a/packages/sdk/src/transactions/index.ts
+++ b/packages/sdk/src/transactions/index.ts
@@ -1,3 +1,4 @@
 export * from "./Inscriber"
+export * from "./InscriberV2"
 export * from "./psbt"
 export * from "./types"

--- a/packages/sdk/src/transactions/types.ts
+++ b/packages/sdk/src/transactions/types.ts
@@ -96,4 +96,4 @@ export interface SkipStrictSatsCheckOptions {
   customAmount?: number
 }
 
-export type TaptreeVersion = "1" | "2"
+export type TaptreeVersion = "1" | "2" | "3"

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -259,3 +259,16 @@ export function getDummyP2TRInput(): UTXO {
     confirmation: 10
   }
 }
+
+export const splitInscriptionId = (inscriptionId: string) => {
+  const [txId, index] = inscriptionId.split(":")
+  if (txId.length !== 64) {
+    throw new OrditSDKError(`Invalid inscriptionId: ${inscriptionId}`)
+  }
+  const indexNum = parseInt(index, 10)
+  if (Number.isNaN(indexNum) || indexNum < 0) {
+    throw new OrditSDKError(`Invalid inscriptionId: ${inscriptionId}`)
+  }
+
+  return { txId, index: parseInt(index, 10) }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Deprecate `Inscriber` class and use `InscriberV2` to support bulk minting as well.
Created `bulkMintFromCollection` function to build necessary params for InscriberV2

also to note that, on the scripting side due to [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) bitcoinjs will try to convert scripts to its smallest possible push operation so `OP_PUSHBYTES_1 01` is the same as `OP_PUSHNUM_1`. This has also been supported by ord [PR](https://github.com/ordinals/ord/pull/2497)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors 
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
